### PR TITLE
add development index

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -1,0 +1,15 @@
+---
+baseurl: ./
+site: website index
+title: website index for development
+---
+
+<!doctype html5>
+<html>
+    <body>
+        <h2>Websites</h2>
+        <ul>
+            <li><a href="/ipfs.io">ipfs.io</a></li>
+        </ul>
+    </body>
+</html>


### PR DESCRIPTION
add a page so that when you open localhost:8081 for development you actually know how to get to the ipfs.io landing page instead of being confronted with 'not found'

if you're not planning to add more websites to this repository, it might make sense to just move ipfs.io into the root of `src`