### PR TITLE
Fix link for "Search github for 'ipfs'".

### DIFF
--- a/src/ipfs.io/docs/index.html
+++ b/src/ipfs.io/docs/index.html
@@ -24,7 +24,7 @@ These are links to some of the IPFS repositories.
 - [github.com/ipfs/ipfs](https://github.com/ipfs/ipfs) - original IPFS paper. Soon the spec too.
 - [github.com/ipfs/go-ipfs](https://github.com/ipfs/go-ipfs) - the main, reference implementation
 - [github.com/protocol/ipfs-webui](https://github.com/protocol/ipfs-webui) - our web console
-- [Search github for "ipfs"](https://github.com/search?p=4&q=%22ipfs%22&ref=searchresults&type=Repositories&utf8=%E2%9C%93)
+- [Search github for "ipfs"](https://github.com/search?q=ipfs&ref=searchresults&type=Repositories&utf8=%E2%9C%93)
 
 ## Community
 


### PR DESCRIPTION
It previously linked to page 4.