### PR TITLE
src/ipfs.io/docs/index.html: irc:// URL for #ipfs

### DIFF
--- a/src/ipfs.io/docs/index.html
+++ b/src/ipfs.io/docs/index.html
@@ -32,7 +32,7 @@ The IPFS community maintains the following communication channels:
 
 - github: [github.com/ipfs/ipfs](https://github.com/ipfs/ipfs) for the IPFS spec
 - github: [github.com/ipfs/go-ipfs](https://github.com/ipfs/go-ipfs) for the go-ipfs implementation
-- IRC: `#ipfs` on irc.freenode.net for live help + some dev discussions ([Logs](https://botbot.me/freenode/ipfs/))
+- IRC: [#ipfs on chat.freenode.net](irc://chat.freenode.net/%23ipfs) for live help + some dev discussions ([Logs](https://botbot.me/freenode/ipfs/))
 - Google Group: [ipfs-users@groups.google.com](https://groups.google.com/forum/#!forum/ipfs-users)
 - Twitter: [@IPFSbot](https://twitter.com/ipfsbot) for some news
 


### PR DESCRIPTION
Apparently there's not an accepted RFC for this, but the syntax I'm
using is compatible with [Mirashi's draft][1], [Butcher's draft][2], and
[Chatzilla][3].  I've also updated the host from irc.freenode.net to
chat.freenode.net to [match their docs][4].

[1]: http://www.w3.org/Addressing/draft-mirashi-url-irc-01.txt
[2]: https://tools.ietf.org/html/draft-butcher-irc-url-04
[3]: http://www-archive.mozilla.org/projects/rt-messaging/chatzilla/irc-urls.html
[4]: http://www.freenode.org/using_the_network.shtml