### PR TITLE
publish-to-github: Use 'test' instead of 'ls' to check build/

### DIFF
--- a/publish-to-github
+++ b/publish-to-github
@@ -6,7 +6,11 @@ site=build/ipfs.io
 set -e
 
 # check we have a build dir
-ls build >/dev/null || (echo "no build/ run make" && exit 1)
+if test ! -d build
+then
+	echo "no build/ directory.  Run make"
+	exit 1
+fi
 
 # patch with mirror note
 cp "$site/index.html" "$site/index2.html"


### PR DESCRIPTION
And unwind the one-liner into less-compact if statement.  This makes
the handling more explicit (e.g. it also errors out if there's a build
file).  I also dropped the && between the echo and the exit.  Even if
we hadn't set -e, we'd still want to exit regardless of whether or not
the echo succeeds.