### PR TITLE
Tweak `whoami` line to make it work

### DIFF
--- a/src/ipfs.io/docs/getting-started/index.html
+++ b/src/ipfs.io/docs/getting-started/index.html
@@ -130,7 +130,7 @@ And, you should be able to give the network objects. Try adding one, and then
 viewing it in your favorite browser:
 
 ```
-> hash=`echo "I <3 IPFS -"\`whoami\` | ipfs add -q`
+> hash=`echo "I <3 IPFS -$(whoami)" | ipfs add -q`
 > curl "http://gateway.ipfs.io/ipfs/$hash"
 I <3 IPFS -<your username>
 ```


### PR DESCRIPTION
Prior to this change I got a file that stated:
```
I <3 IPFS -whoami
```

Hope that tweak is correct and broadly applicable. :smile: 