### PR TITLE
install from source: Note about GOPATH

### DIFF
--- a/src/ipfs.io/docs/install/index.html
+++ b/src/ipfs.io/docs/install/index.html
@@ -69,7 +69,7 @@ Then run:
 go get -u github.com/ipfs/go-ipfs/cmd/ipfs
 ```
 
-This will download ipfs and its dependencies, and compile `ipfs`. Test it out:
+This will download ipfs and its dependencies, and compile `ipfs` (Make sure to add `$GOPATH/bin` to your `$PATH`). Test it out:
 
 ```
 > ipfs version


### PR DESCRIPTION
The `go get ...` might succeed but you still get a `ipfs: file not found` error when you haven't added `$GOPATH/bin` to your `$PATH`.