### PR TITLE
Scale webui screenshot to width of paragraphs

### DIFF
--- a/src/ipfs.io/docs/getting-started/index.html
+++ b/src/ipfs.io/docs/getting-started/index.html
@@ -161,7 +161,7 @@ On your favorite web browser, go to:
 
 This should bring up a console like this:
 
-![Web console connection view](media/webui-connection.png)
+<img class="screenshot" alt="Web console connection view" src="media/webui-connection.png">
 
 Now, you're ready:
 

--- a/styles/style.css
+++ b/styles/style.css
@@ -165,3 +165,8 @@ h1, h2, h3, h4 {
 h5 {
   font-weight: 600;
 }
+
+img.screenshot {
+  width: 100%;
+}
+


### PR DESCRIPTION
This prevents the image spilling outside the bounds of the text