### PR TITLE
Move IPFS full name higher in the page, as it currently is explained …

### DIFF
--- a/src/ipfs.io/index.html
+++ b/src/ipfs.io/index.html
@@ -34,7 +34,7 @@ title: IPFS is a new peer-to-peer hypermedia protocol.
 
 # The IPFS Project
 
-IPFS is a new hypermedia distribution protocol, addressed by content and
+The InterPlanetary File System (IPFS) is a new hypermedia distribution protocol, addressed by content and
 identities. IPFS enables the creation of completely distributed applications.
 It aims to make the web faster, safer, and more open.
 
@@ -46,7 +46,7 @@ from the open source community.
 
 ## How it works
 
-The InterPlanetary File System (IPFS) is a peer-to-peer distributed
+IPFS is a peer-to-peer distributed
 file system that seeks to connect all computing devices
 with the same system of files. In some ways, IPFS
 is similar to the Web, but IPFS could be seen as a single


### PR DESCRIPTION
…after around 6 mentions. This leads the naive user to search for what IPFS means before reading in depth, and can lead to disengagement I think.