### PR TITLE
Added OS Protocol

### DIFF
--- a/tmpl/layouts/white.html
+++ b/tmpl/layouts/white.html
@@ -33,7 +33,11 @@
       <link href="./styles/{{site}}.css" rel="stylesheet" />
     <!--{% endif %}-->
 
-
+    <!-- OS Protocol -->
+    <link rel="profile" href="http://osprotocol.com" />
+    <meta property="os:repo" content="https://github.com/ipfs/website" />
+    <meta property="os:rcs_type" content="git" />
+    <meta property="os:src" content="git@github.com:ipfs/website.git" />
 
     <!-- HTML5 shim and Respond.js for IE8 support of HTML5 elements and media queries -->
     <!--[if lt IE 9]>


### PR DESCRIPTION
In order to edit the website I had to:
 - Click on any link to get to the IPFS GitHub account
 - Assume that the website is a repo in the IPFS organization
 - Find the relevant repository
 - See if it was open for PRs

This should be easier. OS Protocol was made for just this occasion. Another option, equally valid, would be to add a 'This website is hosted at x' line either in the footer or in the Contribute page. 