### PR TITLE
Added links to FAQ and community

### DIFF
--- a/src/ipfs.io/docs/index.html
+++ b/src/ipfs.io/docs/index.html
@@ -32,9 +32,11 @@ The IPFS community maintains the following communication channels:
 
 - github: [github.com/ipfs/ipfs](https://github.com/ipfs/ipfs) for the IPFS spec
 - github: [github.com/ipfs/go-ipfs](https://github.com/ipfs/go-ipfs) for the go-ipfs implementation
+- github: [github.com/ipfs/faq](https://github.com/ipfs/faq) for questions you might have about IPFS
 - IRC: [#ipfs on chat.freenode.net](irc://chat.freenode.net/%23ipfs) for live help + some dev discussions ([Logs](https://botbot.me/freenode/ipfs/))
 - Google Group: [ipfs-users@groups.google.com](https://groups.google.com/forum/#!forum/ipfs-users)
 - Twitter: [@IPFSbot](https://twitter.com/ipfsbot) for some news
+- github: [github.com/ipfs/community](https://github.com/ipfs/community) for meta-questions on how we manage our community in general
 
 
 {% endmarkdown %}


### PR DESCRIPTION
This addresses #12 and also https://github.com/ipfs/community/issues/15. I added the ccommunity link because it is also relevant for some questions that aren't technical.