### PR TITLE
Fix wrong use of FontAwesome icons

### DIFF
--- a/src/ipfs.io/index.html
+++ b/src/ipfs.io/index.html
@@ -62,13 +62,13 @@ point of failure, and nodes do not need to trust each other.
 
 <div class="text-center" style="margin-top: 30px">
 <a class="btn btn-default btn-lg" href="#alpha-demo" role="button">
-  <i class="fa fa-play"> &nbsp; Watch the Demo</i>
+  <i class="fa fa-play"></i> &nbsp; Watch the Demo
 </a> &nbsp;
 <a class="btn btn-default btn-lg" href="https://github.com/ipfs/papers/raw/master/ipfs-cap2pfs/ipfs-p2p-file-system.pdf" role="button">
-  <i class="fa fa-file-o"> &nbsp; Read the Paper</i>
+  <i class="fa fa-file-o"></i> &nbsp; Read the Paper
 </a> &nbsp;
 <a class="btn btn-success btn-lg" href="./docs/install" role="button">
-  <i class="fa fa-download"> &nbsp; Install IPFS</i>
+  <i class="fa fa-download"></i> &nbsp; Install IPFS
 </a>
 </div>
 


### PR DESCRIPTION
Putting text inside of the `<i>` element would cause the wrong font
appearing in the button