### PR TITLE
Fix  <base href="../../" /> that breaks links

### DIFF
--- a/src/ipfs.io/docs/index.html
+++ b/src/ipfs.io/docs/index.html
@@ -1,5 +1,5 @@
 ---
-baseurl: ../
+baseurl: ./
 site: ipfs
 template: tmpl/layouts/ipfs.html
 tagline:


### PR DESCRIPTION
All the #foo links on https://ipfs.io/docs/commands/ are broken.  Pretty sure this will fix it, but I can't easily test.