### PR TITLE
Remove superfluous links

### DIFF
--- a/src/ipfs.io/docs/index.html
+++ b/src/ipfs.io/docs/index.html
@@ -12,8 +12,6 @@ tagline:
 
 ## Documentation
 
-- [Install](docs/install)
-- [Getting Started](docs/getting-started)
 - [Command Reference](docs/commands)
 - [API Reference](docs/api)
 


### PR DESCRIPTION
These links are a click away in the navbar, and are unnecessary in the Documentation column. 

 Related to #56.