### PR TITLE
Update install docs required golang version

### DIFF
--- a/src/ipfs.io/docs/install/index.html
+++ b/src/ipfs.io/docs/install/index.html
@@ -59,7 +59,7 @@ sooner.
 
 Dependencies:
 
-- [Install Go 1.4](https://golang.org/doc/install) (to compile. [make sure it's 1.4](#check-go-version))
+- [Install Go 1.5](https://golang.org/doc/install) (to compile. [make sure it's 1.5](#check-go-version))
 - [Install Git](https://git-scm.com/) (to download dependencies)
 - *Optionally*, install [FUSE](#install-fuse) (for mounting / advanced use)
 


### PR DESCRIPTION
Today I got this message trying to install ipfs:

    $ go get -u github.com/ipfs/go-ipfs/cmd/ipfs package github.com/ipfs/go-ipfs/cmd/ipfs
        imports github.com/ipfs/go-ipfs/cmd/ipfs
        imports github.com/ipfs/go-ipfs/cmd/ipfs: ../../../.go/src/github.com/ipfs/go-ipfs/cmd/ipfs/go_req.go:3:1: expected 'package', found 'STRING' `IPFS needs to be built with go version 1.5 or greater`