### PR TITLE
Changed API link to new repo

### DIFF
--- a/src/ipfs.io/docs/api/index.html
+++ b/src/ipfs.io/docs/api/index.html
@@ -90,9 +90,9 @@ Note that it can be used multiple times to signify multiple arguments:
 ## TODO <i class="fa fa-warning"></i>
 
 This page will contain a listing of all commands and query examples.
-If you're seeing this and you want the api reference faster, let us know here:
+If you're seeing this and you want the api reference faster, let us know or help us out here:
 
-- [github.com/ipfs/go-ipfs/issues/785](https://github.com/ipfs/go-ipfs/issues/785)
+- [github.com/ipfs/api/issues](https://github.com/ipfs/api/issues)
 
 {% endmarkdown %}
 </div>


### PR DESCRIPTION
Changed the link to point to the new API repo. This should help people who want an HTTP api know what the current status is a little easier. 