### PR TITLE
Added a more prominent link to the FAQ

### DIFF
--- a/src/ipfs.io/docs/index.html
+++ b/src/ipfs.io/docs/index.html
@@ -17,6 +17,7 @@ title: Documentation
 - [Getting Started](getting-started)
 - [Command Reference](commands)
 - [API Reference](api)
+- [Frequently Asked Questions (FAQ)](//github.com/ipfs/faq)
 
 ## Code
 


### PR DESCRIPTION
This is the best way to up visibility for this on the website that I could think of. See #44