### PR TITLE
Incorrect link to IRC channel

### DIFF
--- a/src/ipfs.io/docs/index.html
+++ b/src/ipfs.io/docs/index.html
@@ -36,7 +36,7 @@ These are links to some of the IPFS repositories.
 - github: [github.com/ipfs/go-ipfs](https://github.com/ipfs/go-ipfs) for the go-ipfs implementation.
 - github: [github.com/ipfs/faq](https://github.com/ipfs/faq) for questions you might have about IPFS.
 - github: [github.com/ipfs/awesome-ipfs](https://github.com/ipfs/awesome-ipfs) an [awesome-*](https://github.com/sindresorhus/awesome) list of lists to awesome IPFS resources, tools, and applications built on IPFS.
-- IRC: [#ipfs on chat.freenode.net](irc://chat.freenode.net/%23ipfs) for live help + some dev discussions ([Logs](https://botbot.me/freenode/ipfs/))
+- IRC: [#ipfs on chat.freenode.net](irc://chat.freenode.net/ipfs) for live help + some dev discussions ([Logs](https://botbot.me/freenode/ipfs/))
 - Google Group: [ipfs-users@groups.google.com](https://groups.google.com/forum/#!forum/ipfs-users)
 - Twitter: [@IPFSbot](https://twitter.com/ipfsbot) for some news.
 - github: [github.com/ipfs/community](https://github.com/ipfs/community) for meta-questions on how we manage our community in general.


### PR DESCRIPTION
I am new to IRC and am struggling to get into the IPFS channel. I think that this was an issue and I have been talking to the empty %23ipfs channel
This seams to correct that