### PR TITLE
Fix broken links

### DIFF
--- a/src/ipfs.io/docs/index.html
+++ b/src/ipfs.io/docs/index.html
@@ -13,10 +13,10 @@ title: Documentation
 
 ## Documentation
 
-- [Install](install)
-- [Getting Started](getting-started)
-- [Command Reference](commands)
-- [API Reference](api)
+- [Install](install/)
+- [Getting Started](getting-started/)
+- [Command Reference](commands/)
+- [API Reference](api/)
 - [Frequently Asked Questions (FAQ)](//github.com/ipfs/faq)
 
 ## Code

--- a/src/ipfs.io/docs/install/index.html
+++ b/src/ipfs.io/docs/install/index.html
@@ -43,7 +43,7 @@ ipfs version 0.3.8
 
 That's it!
 
-<a class="btn btn-success btn-lg" href="../getting-started" role="button">
+<a class="btn btn-success btn-lg" href="../getting-started/" role="button">
   Getting Started with IPFS &nbsp;&nbsp;<i class="fa fa-arrow-right"></i>
 </a>
 
@@ -88,7 +88,7 @@ ipfs version 0.3.8
 
 That's it!
 
-<a class="btn btn-success btn-lg" href="../getting-started" role="button">
+<a class="btn btn-success btn-lg" href="../getting-started/" role="button">
   Getting Started with IPFS &nbsp;&nbsp;<i class="fa fa-arrow-right"></i>
 </a>
 

--- a/src/ipfs.io/index.html
+++ b/src/ipfs.io/index.html
@@ -17,7 +17,7 @@ title: IPFS is a new peer-to-peer hypermedia protocol.
   <br />
   <br />
     <a href="#alpha-demo" class="btn btn-default btn-outline"><i class="fa fa-play"></i> &nbsp; Watch Demo</a>
-    <a href="./docs/install" class="btn btn-default btn-outline"><i class="fa fa-download"></i> &nbsp; Install IPFS</a>
+    <a href="./docs/install/" class="btn btn-default btn-outline"><i class="fa fa-download"></i> &nbsp; Install IPFS</a>
   </div>
 </div>
 {% endblock %}
@@ -67,7 +67,7 @@ point of failure, and nodes do not need to trust each other.
 <a class="btn btn-default btn-lg" href="https://github.com/ipfs/papers/raw/master/ipfs-cap2pfs/ipfs-p2p-file-system.pdf" role="button">
   <i class="fa fa-file-o"></i> &nbsp; Read the Paper
 </a> &nbsp;
-<a class="btn btn-success btn-lg" href="./docs/install" role="button">
+<a class="btn btn-success btn-lg" href="./docs/install/" role="button">
   <i class="fa fa-download"></i> &nbsp; Install IPFS
 </a>
 </div>
@@ -93,7 +93,7 @@ point of failure, and nodes do not need to trust each other.
     <br />
     <br />
     <br />
-    <a class="btn btn-success btn-lg" href="docs/install" role="button">
+    <a class="btn btn-success btn-lg" href="docs/install/" role="button">
       Install IPFS Alpha &nbsp;&nbsp;<i class="fa fa-arrow-right"></i>
     </a>
     <hr class="ipw-spacer" />

--- a/tmpl/partials/footer.html
+++ b/tmpl/partials/footer.html
@@ -20,13 +20,13 @@
             <div class="ipw-nav-col ipw-centered-left">
               <h5>IPFS</h5>
               <a href="//ipfs.io">About</a><br />
-              <a href="//ipfs.io/docs/install">Install</a><br />
-              <a href="//ipfs.io/docs">Docs</a><br />
+              <a href="//ipfs.io/docs/install/">Install</a><br />
+              <a href="//ipfs.io/docs/">Docs</a><br />
               <a href="//ipfs.io/docs/#code">Code</a><br />
               <a href="//ipfs.io/docs/#community">Community</a><br />
               <!-- <a href="//ipfs.io/ecosystem">Ecosystem</a><br /> -->
               <!-- <a href="//ipfs.io/roadmap">Roadmap</a><br /> -->
-              <a href="//ipfs.io/blog">Blog</a><br />
+              <a href="//ipfs.io/blog/">Blog</a><br />
               <a href="//ipfs.io/legal">Legal</a><br />
             </div>
           </div>

--- a/tmpl/partials/pagenav.html
+++ b/tmpl/partials/pagenav.html
@@ -38,11 +38,11 @@
   <div class="col-xs-12 col-md-8 col-md-offset-2" style="text-align: center;">
     <ul class="nav nav-justified">
       <li {{ active(pgns, 'about') }}><a href="{{ baseurl }}/">About</a></li>
-      <li {{ active(pgns, 'install') }}><a href="{{ baseurl }}/docs/install">Install</a></li>
-      <li {{ active(pgns, 'examples') }}><a href="{{ baseurl }}/docs/examples">Examples</a></li>
-      <li {{ active(pgns, 'docs') }}><a href="{{ baseurl }}/docs">Project</a></li>
-      <li {{ active(pgns, 'blog') }}><a href="{{ baseurl }}/blog">Blog</a></li>
-      <li {{ active(pgns, 'media') }}><a href="{{ baseurl }}/docs/media">Media</a></li>
+      <li {{ active(pgns, 'install') }}><a href="{{ baseurl }}/docs/install/">Install</a></li>
+      <li {{ active(pgns, 'examples') }}><a href="{{ baseurl }}/docs/examples/">Examples</a></li>
+      <li {{ active(pgns, 'docs') }}><a href="{{ baseurl }}/docs/">Project</a></li>
+      <li {{ active(pgns, 'blog') }}><a href="{{ baseurl }}/blog/">Blog</a></li>
+      <li {{ active(pgns, 'media') }}><a href="{{ baseurl }}/docs/media/">Media</a></li>
 
       <!-- <li {{ active(pgns, 'ecosystem') }}><a href="{{ baseurl }}/docs/ecosystem">Ecosystem</a></li> -->
       <!-- <li {{ active(pgns, 'roadmap') }}><a href="{{ baseurl }}/docs/roadmap">Roadmap</a></li> -->


### PR DESCRIPTION
A number of links (including *all* [Install](https://ipfs.io/docs/install) links) on the frontpage of https://ipfs.io/ seem to be broken and lead to a minimal 404 error page.

Local links like `/install` or `/docs` don't resolve (anymore?) and require `/install/` or `/docs/`. For instance, the [Project](https://ipfs.io/docs) link goes to `/docs` and fails to resolve, but https://ipfs.io/docs/ works.

I did a grep through the code looking for instances. Sorry if I'm missing something or my fix is incorrect.