### PR TITLE
Syntax highlighting

### DIFF
--- a/content/pages/docs/getting-started.md
+++ b/content/pages/docs/getting-started.md
@@ -39,7 +39,7 @@ ipfs cat /ipfs/QmYwAPJzv5CZsnA625s3Xf2nemtYgPpHdWEz79ojWnPbdG/readme
 
 You should see something like this:
 
-```sh
+```
 Hello and Welcome to IPFS!
 
 ██╗██████╗ ███████╗███████╗


### PR DESCRIPTION
Removed sh syntax highlighting from the example welcome text. 

A lone single quote was being highlighted as a syntax error on the website and the "for" was being highlighted.