### PR TITLE
Update links in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,13 +52,13 @@ The site is presently built so that all paths are relative, making it easy to de
 
 Here's the key highlights of various important files and folders:
 
-- [`content`](https://github.com/andyet/ipfs.io/tree/master/content) is where the site's content goes. There are subfolders for:
-  - [`pages`](https://github.com/andyet/ipfs.io/tree/master/content/pages) (general site content and documentation)
-  - [`posts`](https://github.com/andyet/ipfs.io/tree/master/content/posts) (blog posts) folder.
-  - [`images`](https://github.com/andyet/ipfs.io/tree/master/content/images) folder for any images associated with a page or blog post
-  - [`static`](https://github.com/andyet/ipfs.io/tree/master/content/static) folder for other kinds of embedded content, like [Asciinema](https://asciinema.org/) files.
-- [`ipfs.io-theme`](https://github.com/andyet/ipfs.io/tree/master/ipfs.io-theme) contains the site's look and feel. This folder includes a `templates` folder, using fairly straightforward templates to build the site with. The `_styl` folder contains the stylus files that are used to build the site's CSS.
-- [`ipfs.io-theme/templates/latest.html`](https://github.com/andyet/ipfs.io/blob/master/ipfs.io-theme/templates/latest.html) automatically adds the latest blog posts, plus includes custom links to featured articles and videos.
+- [`content`](https://github.com/ipfs/website/tree/master/content) is where the site's content goes. There are subfolders for:
+  - [`pages`](https://github.com/ipfs/website/tree/master/content/pages) (general site content and documentation)
+  - [`posts`](https://github.com/ipfs/website/tree/master/content/posts) (blog posts) folder.
+  - [`images`](https://github.com/ipfs/website/tree/master/content/images) folder for any images associated with a page or blog post
+  - [`static`](https://github.com/ipfs/website/tree/master/content/static) folder for other kinds of embedded content, like [Asciinema](https://asciinema.org/) files.
+- [`ipfs.io-theme`](https://github.com/ipfs/website/tree/master/ipfs.io-theme) contains the site's look and feel. This folder includes a `templates` folder, using fairly straightforward templates to build the site with. The `_styl` folder contains the stylus files that are used to build the site's CSS.
+- [`ipfs.io-theme/templates/latest.html`](https://github.com/ipfs/website/blob/master/ipfs.io-theme/templates/latest.html) automatically adds the latest blog posts, plus includes custom links to featured articles and videos.
 - [`pelican-plugins`] just has relevant plugins used by pelican to build the site.
 
 ## Theme


### PR DESCRIPTION
links in README now point to current ipfs/website repo instead of old andyet/ipfs.io repo