### PR TITLE
Added aci discovery tags into head meta tags

### DIFF
--- a/ipfs.io-theme/templates/base.html
+++ b/ipfs.io-theme/templates/base.html
@@ -10,6 +10,8 @@
       <meta name="author" content="">
       <link rel="icon" type="image/png" href="{{ SITEURL }}{{ SITEPATH }}/theme/images/favicon.png">
       <link rel="stylesheet" href="{{ SITEURL }}{{ SITEPATH }}/theme/css/main.css">
+      <meta name="ac-discovery" content="ipfs.io https://dist.ipfs.io/images/{name}-{version}-{os}-{arch}.{ext}">
+      <meta name="ac-discovery-pubkeys" content="ipfs.io https://dist.ipfs.io/ipfs.gpg">
       <script>
         try{Typekit.load({async:true});}catch(e){}
       </script>


### PR DESCRIPTION
This is the first step to getting ipfs.io to serve aci files. 
Next is to update the go-ipfs make file to generate the aci file.
Then sign and upload to https://dist.ipfs.io/ in the correct place with a gpg key available.

Signed Off: Simon Kirkby (tigger@interthingy.com)