### PR TITLE
fixes link to google analytics.js

### DIFF
--- a/ipfs.io-theme/templates/base.html
+++ b/ipfs.io-theme/templates/base.html
@@ -133,7 +133,7 @@
       (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
       (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
       m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-      })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
+      })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
       ga('create', 'UA-52930282-2', 'auto');
       ga('send', 'pageview');
     </script>


### PR DESCRIPTION
Analytics weren't loading properly. I suspect it was because the script references `//www.google-analytics.com/analytics.js` instead of `https://www.google-analytics.com/analytics.js`