### PR TITLE
Add section about installing a browser extension

### DIFF
--- a/content/pages/docs/getting-started.md
+++ b/content/pages/docs/getting-started.md
@@ -153,6 +153,10 @@ This should bring up a console like this:
 
 <img class="screenshot" alt="Web console connection view" src="/images/webui-connection.png">
 
+## Installing a Browser Extension
+
+You can install a browser extension such as [IPFS Gateway Redirect](https://addons.mozilla.org/firefox/addon/ipfs-gateway-redirect/) for Firefox or [IPFS Station](https://chrome.google.com/webstore/detail/ipfs-station/kckhgoigikkadogfdiojcblegfhdnjei) for Chrome. These will automatically redirect IPFS gateway requests to your local daemon so that you are not relying on, or trusting, remote gateways.
+
 Now, you're ready:
 
 <a class="button button-primary" href="../examples" role="button">


### PR DESCRIPTION
I followed the Getting Started guide, but it led me to believe that the current state-of-the art is simply requesting everything through a remote gateway, or manually editing URLs.

It took me quite a bit of searching to find out that browser extensions already exist, and I think many users would benefit from this being included in the Getting Started guide.

I won't mind if you completely reword what I've written :)