### PR TITLE
Fix footer PL links

### DIFF
--- a/ipfs.io-theme/templates/base.html
+++ b/ipfs.io-theme/templates/base.html
@@ -86,9 +86,8 @@
             <div class="grid-flex-cell">
               <ul class="sitemap unstyled">
                 <li class="sitemap-head">Protocol Labs</li>
-                <li><a href="http://ipn.io">About</a></li>
-                <li><a href="http://ipn.io/contact">Contact</a></li>
-                <li><a href="http://ipn.io/join">Join</a></li>
+                <li><a href="https://protocol.ai">About</a></li>
+                <li><a href="https://protocol.ai/join">Join</a></li>
               </ul>
             </div>
             <div class="grid-flex-cell">


### PR DESCRIPTION
Contact links is being removed because protocol.ai doesn't have a contact page.