### PR TITLE
Disable ligatures for monospace text

### DIFF
--- a/ipfs.io-theme/_styl/components/typography.styl
+++ b/ipfs.io-theme/_styl/components/typography.styl
@@ -74,6 +74,7 @@ body
 
 code, pre
   font-family: 'FormularMono'
+  font-variant-ligatures: none
 
 h1, h2, h3, h4, h5, h6
   font-family: 'BrandonTextWeb-Regular'


### PR DESCRIPTION
Never encountered this issue in the wild before, but here's what I'm seeing on Chrome and Firefox on macOS:
<img width="669" alt="screen shot 2017-05-24 at 9 22 28 am" src="https://cloud.githubusercontent.com/assets/5767112/26413984/90a46232-4062-11e7-95cb-e8527927ee51.png">