### PR TITLE
Update content license notice link

### DIFF
--- a/ipfs.io-theme/templates/base.html
+++ b/ipfs.io-theme/templates/base.html
@@ -119,7 +119,7 @@
             </ul>
           </div>
         </div>
-        <p class="footer-copyright center">© Protocol Labs | Except as <a href="http://ipn.io/legal/policies/">noted</a>, content licensed <a href="https://creativecommons.org/licenses/by/3.0/">CC-BY 3.0.</a></p>
+        <p class="footer-copyright center">© Protocol Labs | Except as <a href="https://protocol.ai/legal/">noted</a>, content licensed <a href="https://creativecommons.org/licenses/by/3.0/">CC-BY 3.0.</a></p>
       </div>
     </footer>
     <script src="{{ SITEURL }}{{ SITEPATH }}/theme/js/pixi.min.js" type="text/javascript"></script>


### PR DESCRIPTION
The "Except as noted" link was pointing to http://ipn.io/legal/policies/ which no longer resolves to a thing, so updating it to point to https://protocol.ai/legal/ instead.