### PR TITLE
Fix page title

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -6,13 +6,13 @@
 <link rel="stylesheet" href="/css/main.css" />
 <link rel="icon" type="image/png" href="/images/favicon.png">
 <!-- search and social meta data -->
-<title>{{ .Params.title }}</title>
+<title>{{ $.Param "title" }}</title>
 {{ if isSet .Params "description" }}<meta name="description" content="{{ .Params.description }}" />{{ end }}
 {{ if isSet .Params "author" }}<meta name="author" content="{{ .Params.author }}" />{{ end }}
 <!-- open graph -->
 <meta property="og:type" content="website" />
 <meta property="og:description" content="{{ $.Param "description" }}" />
-<meta property="og:title" content="{{ if isSet .Params "title" }}{{ .Params.title }}{{ else }}{{ .Site.Params.name }}{{ end }}" />
+<meta property="og:title" content="{{ $.Param "title" }}" />
 <meta property="og:site_name" content="{{ .Site.Params.name }}" />
 <meta property="og:url" content="{{ .Permalink }}" />
 <meta property="og:locale" content="en_US">
@@ -23,7 +23,7 @@
 <!--Twitter Cards-->
 <meta name="twitter:card" content="summary" />
 <meta name="twitter:site" content="{{ .Site.Params.name }}" />
-<meta name="twitter:title" content="{{ if isSet .Params "title" }}{{ .Params.title }}{{ else }}{{ .Site.Params.name }}{{ end }}" />
+<meta name="twitter:title" content="{{ $.Param "title" }}" />
 {{ if isSet .Params "author" }}<meta name="twitter:creator" content="{{ .Params.author }}" />{{ end }}
 <meta name="twitter:description" content="{{ $.Param "description" }}" />
 <meta name="twitter:domain" content="{{ .Site.Params.domain }}" />


### PR DESCRIPTION
Fixes title in HTML tag and in open graph and twitter card tags.

Uses [`$.Param`](https://gohugo.io/templates/variables/#param-method) to resolve a single value whether it’s in a page parameter or a site parameter.

fixes #205