### PR TITLE
Prefix /blog to blog post URL

### DIFF
--- a/js/lib/blog-feed.js
+++ b/js/lib/blog-feed.js
@@ -4,7 +4,7 @@ function renderPosts (data) {
   var $container = $('#latest-list')
   $container.empty()
   data.posts.slice(0, 4).forEach(function (post) {
-    var $el = $('<li><span class="date">' + post.date + '</span> <a href="' + post.url + '">' + post.title + '</a></li>')
+    var $el = $('<li><span class="date">' + post.date + '</span> <a href="/blog' + post.url + '">' + post.title + '</a></li>')
     $container.append($el)
   })
 }


### PR DESCRIPTION
Since the blog site is mounted at ipfs.io/blog it's appropriate to add this detail here and not in the blog site i.e. the blog site makes no assumptions about where's it's mounted