### PR TITLE
Changed required version of Go for ipfs-update

### DIFF
--- a/content/docs/install.md
+++ b/content/docs/install.md
@@ -83,7 +83,7 @@ Congratulations! You now have a working IPFS installation on your computer.
 
 `ipfs-update` can be downloaded for your platform at: https://dist.ipfs.io/#ipfs-update
 
-If you have a working Go environment (>=1.7), you can also install it with: `go get -u github.com/ipfs/ipfs-update`.
+If you have a working Go environment (>=1.8), you can also install it with: `go get -u github.com/ipfs/ipfs-update`.
 
 When installing new versions of `ipfs` or upgrading make sure you are using the latest version of `ipfs-update`.
 


### PR DESCRIPTION
The `go get -u github.com/ipfs/ipfs-update` command fails with Go version 1.7.x