### PR TITLE
fix: missing slash in meta headers

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -16,7 +16,7 @@
 <meta property="og:site_name" content="{{ .Site.Params.name }}" />
 <meta property="og:url" content="{{ .Permalink }}" />
 <meta property="og:locale" content="en_US">
-<meta property="og:image" content="{{ .Site.BaseURL }}images/ipfs-logo.svg" />
+<meta property="og:image" content="{{ .Site.BaseURL }}/images/ipfs-logo.svg" />
 <meta property="og:image:type" content="image/svg+xml" />
 <meta property="og:image:width" contentlogo="146" />
 <meta property="og:image:height" content="166" />
@@ -27,7 +27,7 @@
 <meta name="twitter:creator" content="{{ $.Param "author" }}" />
 <meta name="twitter:description" content="{{ $.Param "description" }}" />
 <meta name="twitter:domain" content="{{ .Site.Params.domain }}" />
-<meta name="twitter:image:src" content="{{ .Site.BaseURL }}images/ipfs-logo.svg" />
+<meta name="twitter:image:src" content="{{ .Site.BaseURL }}/images/ipfs-logo.svg" />
 <link href="/blog/index.xml" rel="alternate feed" type="application/rss+xml" title="{{ .Site.Title }}" />
 {{ template "_internal/google_analytics_async.html" . }}
 <script src="/js/blackout.js" async></script>


### PR DESCRIPTION
This change fixes icon links in meta headers.

Broken ones looked like this:

```html
<meta property="og:image" content="https://ipfs.ioimages/ipfs-logo.svg">
<meta name="twitter:image:src" content="https://ipfs.ioimages/ipfs-logo.svg">
```