### PR TITLE
Remove link to newsletter

### DIFF
--- a/layouts/partials/latest.html
+++ b/layouts/partials/latest.html
@@ -42,5 +42,4 @@
       </ul>
     </div>
   </div>
-  <h4 class="content-center">Keep up with IPFS by <a href="https://tinyletter.com/ipfsnewsletter">joining our newsletter »</a></h4>
 </section>


### PR DESCRIPTION
Last update from the newsletter was "June 04, 2016", this commit removes the link as people signing up would expect updates but we're currently not doing any.