### PR TITLE
docs: Add ---s to seprate metadata

### DIFF
--- a/content/docs/api.md
+++ b/content/docs/api.md
@@ -1,9 +1,10 @@
+---
 section: Docs
 title: API | IPFS Docs
 pagetype: subdoc
 url: docs/api
 save_as: docs/api/index.html
-
+---
 
 # API Reference
 


### PR DESCRIPTION
It is not included to divide metadata and content in api.md, so metadata reveal on website. By adding ---s in front of and in back of metadata, it will work well.