### PR TITLE
fix install instructions

### DIFF
--- a/content/docs/install.md
+++ b/content/docs/install.md
@@ -33,7 +33,8 @@ After downloading, untar the archive, and move the `ipfs` binary somewhere in yo
 
 ```sh
 tar xvfz go-ipfs.tar.gz
-./go-ipfs/install.sh
+cd go-ipfs
+./install.sh
 ```
 
 Test it out:


### PR DESCRIPTION
The install script assumes the binary is in the current directory so instructions as written don't work. 