### PR TITLE
deal with two frequently asked questions

### DIFF
--- a/content/docs/getting-started.md
+++ b/content/docs/getting-started.md
@@ -30,15 +30,15 @@ to get started, enter:
 ```
 
 <div class="alert alert-warning">
-If you're running IPFS in the cloud, you should initialize IPFS with the `server` profile (`ipfs init --profile=server`) to avoid aggravating your service provider. See [go-ipfs#4343](https://github.com/ipfs/go-ipfs/issues/4343) for details.
+If you're running IPFS in the cloud, you should initialize IPFS with the <code>server</code> profile (<code>ipfs init --profile=server</code>) to avoid aggravating your service provider. See <a href="https://github.com/ipfs/go-ipfs/issues/4343">go-ipfs#4343</a> for details.
 </div>
 
 <div class="alert alert-info">
-The hash after `peer identity: ` is your peer's ID and will be different from the one shown in the above output. That's how other nodes on the network can find and connect to you. Don't bother writing it down, you can run `ipfs id` at any time if you need it.
+The hash after <code>peer identity: </code> is your peer's ID and will be different from the one shown in the above output. That's how other nodes on the network can find and connect to you. Don't bother writing it down, you can run <code>ipfs id</code> at any time if you need it.
 </div>
 
 <div class="alert alert-info">
-The `HASH` in the `ipfs cat /ipfs/HASH/readme` line above may differ from the `HASH` in your output. If it does, use the one you got. Be sure not to confuse these hashes with your peer identity hash; `ipfs cat /ipfs/PEER_ID/readme` won't work.
+The <code>HASH</code> in the <code>ipfs cat /ipfs/HASH/readme</code> line above may differ from the <code>HASH</code> in your output. If it does, use the one you got. Be sure not to confuse these hashes with your peer identity hash; <code>ipfs cat /ipfs/PEER_ID/readme</code> won't work.
 </div>
 
 Now, try following the instructions given to you by `ipfs init`:
@@ -140,7 +140,7 @@ the DHT, found your machine, requested the file, your machine sent it to the
 gateway, and the gateway sent it to your browser.
 
 <div class="alert alert-warning">
-Note: depending on the state of the network, the `curl` may take a while. The public gateways may be overloaded or having a hard time reaching you.
+Note: depending on the state of the network, the <code>curl</code> may take a while. The public gateways may be overloaded or having a hard time reaching you.
 </div>
 
 You can also check it out at your own local gateway:

--- a/content/docs/getting-started.md
+++ b/content/docs/getting-started.md
@@ -30,10 +30,14 @@ to get started, enter:
 ```
 
 <div class="alert alert-info">
-Note the hash there may differ. If it does, use the one you got.
+The hash after `peer identity: ` is your peer's ID. That's how other nodes on the network can find and connect to you. Don't bother writing it down, you can run `ipfs id` at any time if you need it.
 </div>
 
-Now, try running:
+<div class="alert alert-info">
+Note, `HASH` in the `ipfs cat /ipfs/HASH/readme` command may differ. If it does, use the one you got. Do *not* use your peer ID.
+</div>
+
+Now, try following the instructions given to you by `ipfs init`:
 
 ```sh
 ipfs cat /ipfs/QmYwAPJzv5CZsnA625s3Xf2nemtYgPpHdWEz79ojWnPbdG/readme

--- a/content/docs/getting-started.md
+++ b/content/docs/getting-started.md
@@ -16,7 +16,7 @@ During this tutorial, if you have any questions, feel free to ask them in [https
 
 ## init the repo
 
-`ipfs` uses a global local object repository, added to `~/.ipfs`:
+`ipfs` uses a global local object repository, created at `~/.ipfs`. To initialize it, run:
 
 ```sh
 > ipfs init
@@ -28,6 +28,9 @@ to get started, enter:
   ipfs cat /ipfs/QmYwAPJzv5CZsnA625s3Xf2nemtYgPpHdWEz79ojWnPbdG/readme
 
 ```
+<div class="alert alert-warning">
+If you're running IPFS in the cloud, you should initialize IPFS with the `server` profile (`ipfs init --profile=server`) to avoid aggravating your service provider. See [go-ipfs#4343](https://github.com/ipfs/go-ipfs/issues/4343) for details.
+</div>
 
 <div class="alert alert-info">
 The hash after `peer identity: ` is your peer's ID. That's how other nodes on the network can find and connect to you. Don't bother writing it down, you can run `ipfs id` at any time if you need it.

--- a/content/docs/getting-started.md
+++ b/content/docs/getting-started.md
@@ -28,16 +28,17 @@ to get started, enter:
   ipfs cat /ipfs/QmYwAPJzv5CZsnA625s3Xf2nemtYgPpHdWEz79ojWnPbdG/readme
 
 ```
+
 <div class="alert alert-warning">
 If you're running IPFS in the cloud, you should initialize IPFS with the `server` profile (`ipfs init --profile=server`) to avoid aggravating your service provider. See [go-ipfs#4343](https://github.com/ipfs/go-ipfs/issues/4343) for details.
 </div>
 
 <div class="alert alert-info">
-The hash after `peer identity: ` is your peer's ID. That's how other nodes on the network can find and connect to you. Don't bother writing it down, you can run `ipfs id` at any time if you need it.
+The hash after `peer identity: ` is your peer's ID and will be different from the one shown in the above output. That's how other nodes on the network can find and connect to you. Don't bother writing it down, you can run `ipfs id` at any time if you need it.
 </div>
 
 <div class="alert alert-info">
-Note, `HASH` in the `ipfs cat /ipfs/HASH/readme` command may differ. If it does, use the one you got. Do *not* use your peer ID.
+The `HASH` in the `ipfs cat /ipfs/HASH/readme` line above may differ from the `HASH` in your output. If it does, use the one you got. Be sure not to confuse these hashes with your peer identity hash; `ipfs cat /ipfs/PEER_ID/readme` won't work.
 </div>
 
 Now, try following the instructions given to you by `ipfs init`:

--- a/less/pages/docs.less
+++ b/less/pages/docs.less
@@ -43,6 +43,36 @@
   border-radius: 3px;
 }
 
+.alert {
+    padding: 10px;
+    border-left-width: 4px;
+    border-left-style: solid;
+    margin-bottom: 1em;
+
+    &::after {
+        font-family: emoji;
+        margin-right: 5px;
+        display: block;
+        text-align: right;
+        opacity: 0.5;
+    }
+
+    &.alert-warning {
+        border-color: #eeaa55;
+        background: #ffeecc;
+        &::after {
+            content: "⚠️";
+        }
+    }
+    &.alert-info {
+        border-color: #9edfff;
+        background: #e3f6ff;
+        &::after {
+            content: "ℹ️️";
+        }
+    }
+}
+
 @media (max-width: 970px) {
   .docs-menu {
     margin-bottom: 40px;


### PR DESCRIPTION
1. Warn that users installing IPFS in a shared environment should pass `--profile=server` on init.
2. Clarify that the HASH in `/ipfs/HASH/readme` should *not* be replaced with the peer ID.