### PR TITLE
Direct user back to original terminal after starting daemon

### DIFF
--- a/content/docs/getting-started.md
+++ b/content/docs/getting-started.md
@@ -94,11 +94,11 @@ Gateway server listening on /ip4/127.0.0.1/tcp/8080
 Wait for all three lines to appear.
 
 <div class="alert alert-info">
-Make note of the tcp ports you get. if they are different, use yours in the commands below.
+Make note of the tcp ports you get. If they are different, use yours in the commands below.
 </div>
 
-Now, if you're connected to the network,
-you should be able to see the ipfs addresses of your peers:
+Now, switch back to your original terminal. If you're connected to the network,
+you should be able to see the ipfs addresses of your peers when you run:
 
 ```sh
 > ipfs swarm peers


### PR DESCRIPTION
In the [Getting Started](https://ipfs.io/docs/getting-started/) portion of the docs, under 'Going Online', the user is told to open a new terminal, and run

`> ipfs daemon`

From there, they need to switch back to the original terminal where they initialized the repo (in the previous step), to join the network. This isn't stated explicitly, so a first time user may run 
`> ipfs swarm peers` in the same tab where they started the daemon, and just have it hang. 

The docs update here might help folks avoid this pitfall. 