### PR TITLE
Change all docs links to new site (docs.ipfs.io)

### DIFF
--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -12,11 +12,10 @@
         <div class="grid-flex-cell">
           <ul class="sitemap unstyled">
             <li class="sitemap-head">IPFS</li>
-            <li><a href="//github.com/ipfs/ipfs">About</a></li>
+            <li><a href="//github.com/ipfs/ipfs">GitHub</a></li>
             <li><a href="https://docs.ipfs.io/introduction/install/">Install</a></li>
             <li><a href="/media">Media</a></li>
             <li><a href="https://docs.ipfs.io/">Docs</a></li>
-            <li><a href="https://github.com/ipfs/">Code</a></li>
             <li><a href="https://docs.ipfs.io/#community">Community</a></li>
             <li><a href="/blog/">Blog</a></li>
             <li><a href="/legal/">Legal</a></li>

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -13,11 +13,11 @@
           <ul class="sitemap unstyled">
             <li class="sitemap-head">IPFS</li>
             <li><a href="//github.com/ipfs/ipfs">About</a></li>
-            <li><a href="/docs/install/">Install</a></li>
+            <li><a href="https://docs.ipfs.io/introduction/install/">Install</a></li>
             <li><a href="/media">Media</a></li>
-            <li><a href="/docs/">Docs</a></li>
-            <li><a href="/docs/">Code</a></li>
-            <li><a href="/docs/#community">Community</a></li>
+            <li><a href="https://docs.ipfs.io/">Docs</a></li>
+            <li><a href="https://github.com/ipfs/">Code</a></li>
+            <li><a href="https://docs.ipfs.io/#community">Community</a></li>
             <li><a href="/blog/">Blog</a></li>
             <li><a href="/legal/">Legal</a></li>
           </ul>

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -14,9 +14,9 @@
         {{ else }}
           <li><a href="/">About</a></li>
         {{ end }}
-        <li><a href="/docs/install" {{ if eq .page.Params.pagename "install" }}class="current-item"{{ end }}>Install</a></li>
+        <li><a href="https://docs.ipfs.io/introduction/install/" {{ if eq .page.Params.pagename "install" }}class="current-item"{{ end }}>Install</a></li>
         <li><a href="/media" {{ if eq .page.Type "media" }}class="current-item"{{ end }}>Media</a></li>
-        <li><a href="/docs" {{ if and (eq .page.Type "docs") (not (eq .page.Params.pagename "install")) }}class="current-item"{{ end }}>Docs</a></li>
+        <li><a href="https://docs.ipfs.io/" {{ if and (eq .page.Type "docs") (not (eq .page.Params.pagename "install")) }}class="current-item"{{ end }}>Docs</a></li>
         <li><a href="/blog" {{ if or (eq .page.Type "blog") (eq .page.Data.Singular "author") }}class="current-item"{{ end }}>Blog</a></li>
       </ul>
     </nav>
@@ -27,7 +27,7 @@
           <span class="divider"></span>
           <h3 class="subhead-main">A peer-to-peer hypermedia protocol<br /> to make the web faster, safer, and more open.</h3>
           <div class="cta">
-            <a class="button button-outlined" href="docs/getting-started">Try it</a>
+            <a class="button button-outlined" href="https://docs.ipfs.io/introduction/usage/">Try it</a>
             <a class="button button-outlined popup-youtube" href="https://www.youtube.com/watch?v=8CMxDNuuAiQ">Watch demo</a>
           </div>
         </div>


### PR DESCRIPTION
Our new official docs site, with much more info, is now at https://docs.ipfs.io instead of the `/docs` directory that is part of this site. This PR changes all the menu links to point to it. I went ahead and linked that URL, but let me know if there’s some other way we should do this.

This doesn't remove that directory from this site, though — a few examples in the new docs site still come from here, plus I'm not sure if we are ready to break these links yet.

`ipfs/blog` also has matching header/footer templates, so I’ll add a PR over there as soon as it seems like people are happy with the way I’ve rewritten things here.