### PR TITLE
Clean up "version"-related text on home page

### DIFF
--- a/content/index.html
+++ b/content/index.html
@@ -27,7 +27,7 @@
                     <h5 class="content-center"><strong>Humanity's history is deleted daily</strong></h5>
                     <p><a href="https://blogs.loc.gov/thesignal/2011/11/the-average-lifespan-of-a-webpage/">The average lifespan of a web page is 100 days.</a> Remember GeoCities? The web doesn't anymore. It's not good enough for the primary medium
                         of our era to be so fragile.</p>
-                    <p>IPFS provides historic versioning (like git) and makes it simple to set up resilient networks for mirroring of data.</p>
+                    <p>IPFS keeps every version of your files and makes it simple to set up resilient networks for mirroring of data.</p>
                 </div>
                 <div class="grid-flex-cell-1of2">
                     <div class="illustration">
@@ -71,7 +71,7 @@
                     <img src="/images/ipfs-illustrations-how-2.svg" />
                 </div>
                 <div class="how-description">
-                    <h5>IPFS <strong>removes duplications</strong> across the network and tracks <strong>version history</strong> for every file.</h5>
+                    <h5>IPFS <strong>removes duplications</strong> across the network.</h5>
                 </div>
             </div>
             <div class="how-item">


### PR DESCRIPTION
The text we use on the home page to describe IPFS’s support for “versioning” can be confusing to a lot of people. There is a narrow but critical difference between tracking *history* and storing *versions* of files, and the existing language conflates the two. This aims to make sure we are only talking about the latter case (because there are no built-in features that link versions together into a history). Fixes #268.

I’m happy to workshop these changes if people feel like they say too much or too little or aren’t clear enough. I’ve tried to remove the confusion without *totally* removing all language about the fact that IPFS can store multiple versions of a file.

See ipfs/docs#109 for future work crafting a guide to get more into the details about what we mean by versioning and how someone can build tooling around version *histories* on top of the rich primitives IPFS offers. (Also: would love it if someone wanted to take a crack at a draft of that guide!)