### PR TITLE
fix: make Blog and other links work over IPNS

### DIFF
--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -13,11 +13,11 @@
           <ul class="sitemap unstyled">
             <li class="sitemap-head">IPFS</li>
             <li><a href="//github.com/ipfs/ipfs">GitHub</a></li>
-            <li><a href="https://docs.ipfs.io/introduction/install/">Install</a></li>
+            <li><a href="//docs.ipfs.io/introduction/install/">Install</a></li>
             <li><a href="/media">Media</a></li>
-            <li><a href="https://docs.ipfs.io/">Docs</a></li>
-            <li><a href="https://docs.ipfs.io/#community">Community</a></li>
-            <li><a href="/blog/">Blog</a></li>
+            <li><a href="//docs.ipfs.io/">Docs</a></li>
+            <li><a href="//docs.ipfs.io/#community">Community</a></li>
+            <li><a href="//blog.ipfs.io/">Blog</a></li>
             <li><a href="/legal/">Legal</a></li>
           </ul>
         </div>

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -14,10 +14,10 @@
         {{ else }}
           <li><a href="/">About</a></li>
         {{ end }}
-        <li><a href="https://docs.ipfs.io/introduction/install/" {{ if eq .page.Params.pagename "install" }}class="current-item"{{ end }}>Install</a></li>
+        <li><a href="//docs.ipfs.io/introduction/install/" {{ if eq .page.Params.pagename "install" }}class="current-item"{{ end }}>Install</a></li>
         <li><a href="/media" {{ if eq .page.Type "media" }}class="current-item"{{ end }}>Media</a></li>
-        <li><a href="https://docs.ipfs.io/" {{ if and (eq .page.Type "docs") (not (eq .page.Params.pagename "install")) }}class="current-item"{{ end }}>Docs</a></li>
-        <li><a href="/blog" {{ if or (eq .page.Type "blog") (eq .page.Data.Singular "author") }}class="current-item"{{ end }}>Blog</a></li>
+        <li><a href="//docs.ipfs.io/" {{ if and (eq .page.Type "docs") (not (eq .page.Params.pagename "install")) }}class="current-item"{{ end }}>Docs</a></li>
+        <li><a href="//blog.ipfs.io/" {{ if or (eq .page.Type "blog") (eq .page.Data.Singular "author") }}class="current-item"{{ end }}>Blog</a></li>
       </ul>
     </nav>
     {{ if eq .hero "homepage" }}
@@ -27,7 +27,7 @@
           <span class="divider"></span>
           <h3 class="subhead-main">A peer-to-peer hypermedia protocol<br /> to make the web faster, safer, and more open.</h3>
           <div class="cta">
-            <a class="button button-outlined" href="https://docs.ipfs.io/introduction/usage/">Try it</a>
+            <a class="button button-outlined" href="//docs.ipfs.io/introduction/usage/">Try it</a>
             <a class="button button-outlined popup-youtube" href="https://www.youtube.com/watch?v=8CMxDNuuAiQ">Watch demo</a>
           </div>
         </div>


### PR DESCRIPTION
In this PR:

- Switch header/footer links to use separate fqdn for blog (`blog.ipfs.io`) so it loads ok over IPNS
  - See [https://ipfs.io/blog](https://ipfs.io/blog#x-ipfs-companion-no-redirect) vs. https://ipfs.io/ipns/ipfs.io/blog
- Avoid redirect step by using protocol-relative URLs (`ipns://`)

cc https://github.com/ipfs/website/issues/131, https://github.com/ipfs/blog/issues/116, https://github.com/ipfs/blog/issues/100