### PR TITLE
fix: redirect /docs to new docs site

### DIFF
--- a/content/docs/api.md
+++ b/content/docs/api.md
@@ -6,6 +6,13 @@ url: docs/api
 save_as: docs/api/index.html
 ---
 
+## Documentation Moved!
+
+For the up-to-date instructions see [docs.ipfs.io/reference/api/http/](https://docs.ipfs.io/reference/api/http/) :-)
+
+
+<!--
+
 # API Reference
 
 <sup>Generated on 2017-08-23, from go-ipfs v0.4.11-dev.</sup>
@@ -3521,3 +3528,4 @@ On success, the call to this endpoint will return with 200 and the following bod
 
 ***
 
+-->

--- a/content/docs/getting-started.md
+++ b/content/docs/getting-started.md
@@ -5,6 +5,11 @@ pagetype: subdoc
 url: docs/getting-started
 save_as: docs/getting-started/index.html
 ---
+## Documentation Moved!
+
+For the up-to-date instructions see [docs.ipfs.io/introduction/usage](https://docs.ipfs.io/introduction/usage/) :-)
+
+<!--
 
 # Getting Started
 
@@ -160,3 +165,4 @@ Now, you're ready:
 <a class="button button-primary" href="../examples" role="button">
   Onward to more Examples &nbsp;&nbsp;<i class="fa fa-arrow-right"></i>
 </a>
+-->

--- a/content/docs/index.md
+++ b/content/docs/index.md
@@ -6,6 +6,12 @@ constellation: constellation-01.svg
 save_as: docs/index.html
 ---
 
+## Documentation Moved!
+
+Go to [docs.ipfs.io](https://docs.ipfs.io) :-)
+
+<!--
+
 ## Code
 
 These are links to some of the IPFS repositories.
@@ -22,7 +28,7 @@ These are links to some of the IPFS repositories.
 - <a class='link-github' href='https://github.com/ipfs/ipfs'>ipfs/ipfs</a> as a landing repository, with links to various other repositories.
 - <a class='link-github' href='https://discuss.ipfs.io/'>Discourse</a> for issues with getting ipfs up and running.
 - <a class='link-github' href='https://github.com/ipfs/go-ipfs'>ipfs/go-ipfs</a> for the go-ipfs implementation.
-- <a class='link-github' href='https://github.com/ipfs/faq'>ipfs/faq</a> for questions you might have about IPFS.
+- <a class='link-github' href='https://discuss.ipfs.io/c/help'>Community Help</a> for questions you might have about IPFS.
 - <a class='link-github' href='https://github.com/ipfs/reading-list'>ipfs/reading-list</a> for papers to read to understand IPFS.
 - <a class='link-github' href='https://github.com/ipfs/awesome-ipfs'>ipfs/awesome-ipfs</a> an [awesome-*](https://github.com/sindresorhus/awesome) list of IPFS resources, tools, and applications built on IPFS.
 - IRC: [#ipfs on chat.freenode.net](irc://chat.freenode.net/ipfs) for live help + some dev discussions ([Logs](https://botbot.me/freenode/ipfs/))
@@ -30,3 +36,5 @@ These are links to some of the IPFS repositories.
 - Twitter: [@IPFSbot](https://twitter.com/ipfsbot) for some news.
 - <a class='link-github' href='https://github.com/ipfs/community'>ipfs/community</a> for meta-questions on how we manage our community in general.
 - Discourse: [discuss.ipfs.io](https://discuss.ipfs.io) for the main place to ask questions, share information and find like-minded people who are using IPFS, libp2p, multiformats, orbit, orbit-db, IPLD, or any of the other libraries, tools and protocols created by the IPFS community.
+
+-->

--- a/content/docs/install.md
+++ b/content/docs/install.md
@@ -7,6 +7,11 @@ url: docs/install
 save_as: docs/install/index.html
 ---
 
+## Documentation Moved!
+
+For the up-to-date instructions see [docs.ipfs.io/introduction/install](https://docs.ipfs.io/introduction/install/) :-)
+
+<!--
 # Install Go IPFS
 
 We recommend installing IPFS from a prebuilt package:
@@ -210,3 +215,5 @@ Package managers often contain out-of-date Go packages.
 ### Install FUSE
 
 For more details on setting up FUSE (so that you can mount the filesystem), see [github.com/ipfs/go-ipfs/blob/master/docs/fuse.md](https://github.com/ipfs/go-ipfs/blob/master/docs/fuse.md)
+
+-->

--- a/layouts/docs/single.html
+++ b/layouts/docs/single.html
@@ -2,37 +2,23 @@
 <html>
 
 <head>
-  {{ partial "head.html" . }}
+ {{ if eq .RelPermalink "/docs/install/" }}
+  <meta http-equiv="refresh" content="0; URL=https://docs.ipfs.io/introduction/install/" />
+ {{ else if eq .RelPermalink "/docs/getting-started/" }}
+  <meta http-equiv="refresh" content="0; URL=https://docs.ipfs.io/introduction/usage/" />
+ {{ else if eq .RelPermalink "/docs/commands/" }}
+  <meta http-equiv="refresh" content="0; URL=https://docs.ipfs.io/reference/api/cli/" />
+ {{ else if eq .RelPermalink "/docs/api/" }}
+  <meta http-equiv="refresh" content="0; URL=https://docs.ipfs.io/reference/api/http/" />
+ {{ else if eq .RelPermalink "/docs/examples/" }}
+  <meta http-equiv="refresh" content="0; URL=https://docs.ipfs.io/guides/examples/" />
+ {{ else }}
+  <meta http-equiv="refresh" content="0; URL=https://docs.ipfs.io/" />
+ {{ end }}
 </head>
 
 <body>
-  {{ partial "header.html" (dict "hero" "" "baseUrl" ($.Param " baseURL ") "page" .) }}
-
-  <div class="container">  
-    <section id="content" class="body blog">
-      <ul class="docs-menu">
-        <li><a href="/docs" {{ if eq .Params.pagetype "major" }}class="current-item"{{ end }}>Documentation</a></li>
-        <li><a href="/docs/install" {{ if eq .Params.URL "docs/install" }}class="current-item"{{ end }}>Install</a></li>
-        <li><a href="/docs/getting-started" {{ if eq .Params.URL "docs/getting-started" }}class="current-item"{{ end }}>Getting Started</a></li>
-        <li><a href="/docs/api" {{ if eq .Params.URL "docs/api" }}class="current-item"{{ end }}>API</a></li>
-        <li><a href="/docs/commands" {{ if eq .Params.URL "docs/commands" }}class="current-item"{{ end }}>Commands</a></li>
-        <li><a href="/docs/examples" {{ if eq .Params.URL "docs/examples" }}class="current-item"{{ end }}>Examples</a></li>
-      </ul>
-      <div class="content-wrapper">
-        {{ .Content }}
-      </div>
-      <!-- /.entry-content -->
-    </section>
-
-    <div class="content-wrapper">
-        {{ partial "latest.html" . }}
-    </div>
-      
-  </div>
-
-  {{ partial "footer.html" . }}
-  <script src="/js/common.js"></script>  
-  <script src="/js/header-and-latest.js"></script>  
+  Moved to <a href="https://docs.ipfs.io/">docs.ipfs.io</a>
 </body>
 
 </html>


### PR DESCRIPTION
Context: https://github.com/ipfs/website/issues/271

In short there are various places that link to the old URL (https://ipfs.io/docs).
This PR adds manual redirect that ensures everyone will get redirected to  the up-to-date docs website. 

Subsection links will still work, `<meta>` redirect will point at versions at the new website:

- https://ipfs.io/docs/getting-started/ → https://docs.ipfs.io/introduction/usage/
- https://ipfs.io/docs/commands →  https://docs.ipfs.io/reference/api/cli/
- https://ipfs.io/docs/api → https://docs.ipfs.io/reference/api/http/
- https://ipfs.io/docs/examples → https://docs.ipfs.io/guides/examples/

And for everything else in `/docs/*` redirects to the root of the new website:

- https://ipfs.io/docs → https://docs.ipfs.io

Relevant snippet:

https://github.com/ipfs/website/blob/5b15fd080e8a1fc1a619929a02c6e529c8d5e416/layouts/docs/single.html#L5-L17

[preview](https://cloudflare-ipfs.com/ipfs/QmbwEsVrFmTRbCh7GxSoDQkZq2gnSTHcxSmAS6Ep6n7tNo/)

Closes  #271 cc @ipfs/documentation 