### PR TITLE
fix: centered text

### DIFF
--- a/layouts/partials/implementations.html
+++ b/layouts/partials/implementations.html
@@ -45,7 +45,7 @@
             <img src="/images/ipfs-companion-ss.png" />
           </div>
           <h5 class="content-center">Browser Companion</h5>
-          <p>Upgrade your browser with IPFS super powers. This add-on enables everyone to access IPFS resources the way they
+          <p align="left">Upgrade your browser with IPFS super powers. This add-on enables everyone to access IPFS resources the way they
             were meant to.</p>
         </a>
       </div>


### PR DESCRIPTION
Fixes the following:

<img width="1141" alt="ss" src="https://user-images.githubusercontent.com/33324750/51922184-6ffcdd80-23e0-11e9-88a6-ac0a2d6c6655.png">

@daviddias @olizilla 