### PR TITLE
chore: bring back deploy via CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,46 @@
+version: 2
+jobs:
+  build:
+    docker:
+      - image: circleci/node:10.15.1
+    steps:
+      - checkout
+      - run:
+          command: make
+      - persist_to_workspace:
+          root: .
+          paths:
+            - public
+
+  deploy:
+    docker:
+      - image: olizilla/ipfs-dns-deploy:1.1
+        environment:
+          DOMAIN: website.ipfs.io
+          BUILD_DIR: public
+    steps:
+      - attach_workspace:
+          at: /tmp/workspace
+      - run:
+          name: Deploy website to IPFS
+          command: |
+            pin_name="$DOMAIN build $CIRCLE_BUILD_NUMBER"
+
+            hash=$(pin-to-cluster.sh "$pin_name" /tmp/workspace/$BUILD_DIR)
+
+            echo "Website added to IPFS: https://ipfs.io/ipfs/$hash"
+
+            # Update DNSlink for prod or dev domain
+            if [ "$CIRCLE_BRANCH" == "master" ] ; then
+              dnslink-dnsimple -d $DOMAIN -r _dnslink -l /ipfs/$hash
+            fi
+
+workflows:
+  version: 2
+  build-deploy:
+    jobs:
+      - build
+      - deploy:
+          context: ipfs-dns-deploy
+          requires:
+            - build

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 [![](https://img.shields.io/badge/made%20by-Protocol%20Labs-blue.svg?style=flat-square)](http://ipn.io)
 [![](https://img.shields.io/badge/project-ipfs-blue.svg?style=flat-square)](http://github.com/ipfs/ipfs)
 [![](https://img.shields.io/badge/standard--readme-OK-green.svg?style=flat-square)](https://github.com/RichardLitt/standard-readme)
+[![build status](https://img.shields.io/circleci/project/github/ipfs/website/master.svg?style=flat-square)](https://circleci.com/gh/ipfs/website)
 
 > Official website for IPFS http://ipfs.io
 

--- a/ci/Jenkinsfile
+++ b/ci/Jenkinsfile
@@ -1,4 +1,0 @@
-website([
-  website: 'website.ipfs.io',
-  record: '_dnslink'
-])


### PR DESCRIPTION
this time in circleci flavour

see: https://github.com/ipfs-shipyard/ipfs-dns-deploy

there is another PR to set this up for blog.ipfs.io too: https://github.com/ipfs/blog/pull/218

TODO
- [x] add ipfs/website to circleci
- [x] get @ipfsbot access to the repo
- [x] create an ipfs-dns-deploy context on circle ci
- [x] add the vars to the context as per https://github.com/ipfs-shipyard/ipfs-dns-deploy#requirements

License: MIT
Signed-off-by: Oli Evans <oli@tableflip.io>