### PR TITLE
Install Section on IPFS Homepage

### DIFF
--- a/content/index.html
+++ b/content/index.html
@@ -105,6 +105,7 @@
             </div>
         </section>
 
+        {{ partial "install.html" . }}
         {{ partial "implementations.html" . }}
 
         <section id="uses" class="content-center">

--- a/content/index.html
+++ b/content/index.html
@@ -101,7 +101,7 @@
             </div>
             <div class="content-center">
                 <h5>For a deeper look at IPFS</h5>
-                <a class="button button-primary" href="https://github.com/ipfs/papers/raw/master/ipfs-cap2pfs/ipfs-p2p-file-system.pdf">Read the white paper</a>
+                <a class="button button-primary button-whitepaper" href="https://github.com/ipfs/papers/raw/master/ipfs-cap2pfs/ipfs-p2p-file-system.pdf">Read the white paper</a>
             </div>
         </section>
 

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -13,7 +13,7 @@
         {{ else }}
           <li><a href="/">About</a></li>
         {{ end }}
-        <li><a href="//docs.ipfs.io/introduction/install/" {{ if eq .page.Params.pagename "install" }}class="current-item"{{ end }}>Install</a></li>
+        <li><a href="/#install">Install</a></li>
         <li><a href="/media" {{ if eq .page.Type "media" }}class="current-item"{{ end }}>Media</a></li>
         <li><a href="//docs.ipfs.io/" {{ if and (eq .page.Type "docs") (not (eq .page.Params.pagename "install")) }}class="current-item"{{ end }}>Docs</a></li>
         <li><a href="//blog.ipfs.io/" {{ if or (eq .page.Type "blog") (eq .page.Data.Singular "author") }}class="current-item"{{ end }}>Blog</a></li>

--- a/layouts/partials/install.html
+++ b/layouts/partials/install.html
@@ -1,0 +1,17 @@
+<section id="install">
+    <div class="container">
+  
+      <h2 class="content-center">Install</h2>
+      <div class="grid-flex-container">
+        <div class="grid-flex-cell-1of2">
+            <h3 class="content-center">Quick Start</h3>
+                <h5><a href="https://docs.ipfs.io/introduction/install/">Install IPFS on your machine</a></h5>
+                <code>ipfs init # create ipfs local config file</code>
+                <code>ipfs daemon # start the ipfs deamon process</code>
+                <code>ipfs cat # show ipfs object data</code>
+                <code>ipfs get # download ipfs objects</code>
+                <code>ipfs ls # list links from an object</code>
+                <code>ipfs refs # list hashes of links from an object</code>
+        </div>      
+    </div>
+  </section>

--- a/layouts/partials/install.html
+++ b/layouts/partials/install.html
@@ -1,10 +1,10 @@
 <section id="install">
-    <div class="container">
+    <div class="container content-center">
   
-      <h2 class="content-center">Install</h2>
+      <h2>Install</h2>
       <div class="grid-flex-container">
-        <div class="grid-flex-cell-1of2">
-            <h3 class="content-center">Quick Start</h3>
+        <div class="grid-flex-cell">
+            <h3>Quick Start</h3>
                 <h5><a href="https://docs.ipfs.io/introduction/install/">Install IPFS on your machine</a></h5>
                 <code>ipfs init # create ipfs local config file</code>
                 <code>ipfs daemon # start the ipfs deamon process</code>

--- a/layouts/partials/install.html
+++ b/layouts/partials/install.html
@@ -1,11 +1,11 @@
 <section id="install">
     <div class="container content-center">
   
-      <h2>Install</h2>
+      <h1 class="install-title">Install</h1>
+      <hr class="install-underline">
       <div class="grid-flex-container">
         <div class="grid-flex-cell">
-            <h3>Quick Start</h3>
-                <h5><a href="https://docs.ipfs.io/introduction/install/">Install IPFS on your machine</a></h5>
+                <h5 class="install-link-heading"><a href="https://docs.ipfs.io/introduction/install/">Install IPFS on your machine</a></h5>
                     <article class="center mw5 mw6-ns hidden ba mv4 code-box">
                         <div class="pa3 bt tj">
                             <p>ipfs init # create ipfs local config file</p>

--- a/layouts/partials/install.html
+++ b/layouts/partials/install.html
@@ -5,7 +5,8 @@
       <hr class="install-underline">
       <div class="grid-flex-container">
         <div class="grid-flex-cell">
-                <h5 class="install-link-heading"><a href="https://docs.ipfs.io/introduction/install/">Install IPFS on your machine</a></h5>
+                <h4 class="install-link-heading"><a href="https://docs.ipfs.io/introduction/install/">Install IPFS on your machine</a></h4>
+                    <h5>After you have installed IPFS, get started adding files to the distributed web!</h5>
                     <article class="center mw5 mw6-ns hidden ba mv4 code-box">
                         <div class="pa3 bt tj">
                             <p>ipfs init # create ipfs local config file</p>
@@ -16,6 +17,7 @@
                             <p>ipfs refs # list hashes of links from an object</p>
                         </div>
                     </article>
+                    <h4>Is the command line not your jam? Download <a href="https://github.com/ipfs-shipyard/ipfs-desktop">ipfs-desktop</a>!</h4>
             </div>      
         </div>
     </section>

--- a/layouts/partials/install.html
+++ b/layouts/partials/install.html
@@ -1,23 +1,27 @@
 <section id="install">
     <div class="container content-center">
   
-      <h1 class="install-title">Install</h1>
+      <h2 class="install-title">Install</h2>
       <hr class="install-underline">
       <div class="grid-flex-container">
         <div class="grid-flex-cell">
-                <h4 class="install-link-heading"><a href="https://docs.ipfs.io/introduction/install/">Install IPFS on your machine</a></h4>
-                    <h5>After you have installed IPFS, get started adding files to the distributed web!</h5>
-                    <article class="center mw5 mw6-ns hidden ba mv4 code-box">
-                        <div class="pa3 bt tj">
-                            <p>ipfs init # create ipfs local config file</p>
-                            <p>ipfs daemon # start the ipfs deamon process</p>
-                            <p>ipfs cat # show ipfs object data</p>    
-                            <p>ipfs get # download ipfs objects</p>
-                            <p>ipfs ls # list links from an object</p>        
-                            <p>ipfs refs # list hashes of links from an object</p>
-                        </div>
-                    </article>
-                    <h4>Is the command line not your jam? Download <a href="https://github.com/ipfs-shipyard/ipfs-desktop">ipfs-desktop</a>!</h4>
+            <ol class="list install-link-heading tc">
+                <li><h5><a class="link white" href="https://docs.ipfs.io/introduction/install/">1. Install IPFS on your machine</a></h5></li>
+                <li><h5>2. After installation, get started adding and working with files on IPFS.</h5></li>
+            </ol>
+            <article class="center mw5 mw6-ns hidden ba mv4 code-box">
+                <div class="pa3 bt tj code-box">
+                    <p class="code-comment"># create ipfs local config file</p>
+                    <p>ipfs init</p>
+                    <p class="code-comment"># start the ipfs deamon process</p>
+                    <p>ipfs daemon</p>
+                    <p class="code-comment"># show ipfs object data</p>
+                    <p>ipfs cat</p>
+                    <p class="code-comment"># download ipfs objects</p>
+                    <p>ipfs get</p>
+                </div>
+            </article>
+            <h5>Is the command line not your jam? Download <a href="https://github.com/ipfs-shipyard/ipfs-desktop">ipfs-desktop</a>!</h5>
             </div>      
         </div>
     </section>

--- a/layouts/partials/install.html
+++ b/layouts/partials/install.html
@@ -6,12 +6,18 @@
         <div class="grid-flex-cell">
             <h3>Quick Start</h3>
                 <h5><a href="https://docs.ipfs.io/introduction/install/">Install IPFS on your machine</a></h5>
-                <code>ipfs init # create ipfs local config file</code>
-                <code>ipfs daemon # start the ipfs deamon process</code>
-                <code>ipfs cat # show ipfs object data</code>
-                <code>ipfs get # download ipfs objects</code>
-                <code>ipfs ls # list links from an object</code>
-                <code>ipfs refs # list hashes of links from an object</code>
-        </div>      
-    </div>
-  </section>
+                    <article class="center mw5 mw6-ns hidden ba mv4 code-box">
+                        <div class="pa3 bt tj">
+                            <p>ipfs init # create ipfs local config file</p>
+                            <p>ipfs daemon # start the ipfs deamon process</p>
+                            <p>ipfs cat # show ipfs object data</p>    
+                            <p>ipfs get # download ipfs objects</p>
+                            <p>ipfs ls # list links from an object</p>        
+                            <p>ipfs refs # list hashes of links from an object</p>
+                        </div>
+                    </article>
+            </div>      
+        </div>
+    </section>
+
+

--- a/less/main.less
+++ b/less/main.less
@@ -22,6 +22,7 @@
 @import 'components/code';
 @import 'components/blog';
 @import (less) 'node_modules/magnific-popup/dist/magnific-popup.css';
+@import (less) 'node_modules/tachyons/css/tachyons.css';
 
 @import 'pages/home';
 @import 'pages/docs';

--- a/less/pages/home.less
+++ b/less/pages/home.less
@@ -68,9 +68,44 @@
   }
 }
 
+.install-underline {
+  width: 50px;
+  height: 3px;
+  border-radius: 3px;
+  background: @brand-teal;
+  display: block;
+  margin: 0 auto;
+}
+
+section#install:after {
+  display: none;
+}
+
+.install-link-heading {
+    margin-top: 35px;
+
+}
+
+.install-title {
+  color: white;
+  margin-bottom: 20px;
+}
+
 #install .code-box {
   background-color: black;
   font-family: monospace;
+}
+
+#install p {
+  color: #6acad1;
+}
+
+.button-whitepaper {
+  margin-bottom: 75px;
+}
+
+section:after #install {
+  display: none;
 }
 
 .latest-list {

--- a/less/pages/home.less
+++ b/less/pages/home.less
@@ -4,7 +4,8 @@
 *
 --------------------------------------------------------------------*/
 
-#implementations {
+#implementations,
+&#install {
   @color-white: #fff;
   @color-grey: rgba( 255, 255, 255, 0.6);
   @color-teal: #6acad1;
@@ -13,7 +14,7 @@
   width: 100vw;
   left: 50%;
   margin-left: -50vw;
-  margin-top: 80px;
+  // margin-top: 80px;
   padding-bottom: 40px;
   background: fade(@blue-space, 100%);
   background-image: url('../images/stars.png'), linear-gradient(to bottom, fade(@blue-space, 100%) 0%,#062b3f 100%);
@@ -65,6 +66,11 @@
       border: 1px solid @color-grey;
     }
   }
+}
+
+#install .code-box {
+  background-color: black;
+  font-family: monospace;
 }
 
 .latest-list {

--- a/less/pages/home.less
+++ b/less/pages/home.less
@@ -83,7 +83,6 @@ section#install:after {
 
 .install-link-heading {
     margin-top: 35px;
-
 }
 
 .install-title {
@@ -91,13 +90,17 @@ section#install:after {
   margin-bottom: 20px;
 }
 
-#install .code-box {
+.code-box {
   background-color: black;
   font-family: monospace;
 }
 
 #install p {
-  color: #6acad1;
+  color: #63c8cf;
+}
+
+#install p.code-comment {
+  color: white;
 }
 
 .button-whitepaper {

--- a/package.json
+++ b/package.json
@@ -1,12 +1,14 @@
 {
   "name": "ipfs.io",
   "private": true,
-  "dependencies": {},
+  "dependencies": {
+    "ipfs-css": "^0.12.0"
+  },
   "devDependencies": {
     "browserify": "^14.4.0",
     "dnslink-deploy": "^1.0.7",
     "factor-bundle": "^2.5.0",
-    "hugo-bin": "0.18.1",
+    "hugo-bin": "^0.42.0",
     "imagemin-cli": "^3.0.0",
     "imagemin-jpegtran": "^5.0.2",
     "imagemin-optipng": "^5.2.1",
@@ -21,6 +23,7 @@
     "npm-run-all": "^4.1.5",
     "pixi.js": "^4.5.3",
     "standard": "^10.0.2",
+    "tachyons": "^4.10.0",
     "uglify-js": "^3.0.18",
     "watchify": "^3.9.0"
   },


### PR DESCRIPTION
In an effort to make it easier for users to quickly get started with IPFS, I added an `Install` section above `Implementations`. The `Install` section shows users where they can download IPFS and a list of basic CLI commands. This PR addresses https://github.com/ipfs/website/issues/293, https://github.com/ipfs/website/issues/227 https://github.com/ipfs/website/issues/242

![](https://res.cloudinary.com/blockchain-side-hustle/image/upload/v1553082521/Screen_Shot_2019-03-19_at_5.35.42_PM_ylty2r.png)

Debating if I should add an ipfs-companion link next to ipfs-desktop. 