### PR TITLE
feat: include ipfs-camp ribbon

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -30,4 +30,6 @@
 <meta name="twitter:image:src" content="{{ .Site.BaseURL }}/images/ipfs-logo.svg" />
 <link rel="canonical" href="{{ .Permalink }}" />
 <link rel="alternate feed" href="//blog.ipfs.io/index.xml" type="application/rss+xml" title="IPFS Blog" />
+<!-- ipfs camp -->
+<script src="https://camp.ipfs.io/ribbon.min.js" async></script>
 {{ template "_internal/google_analytics_async.html" . }}


### PR DESCRIPTION
This implements the IPFS Camp ribbon banner 💅

Currently only visible on larger screen layouts however I may also add a smaller screen variant once I've had chance to evaluate the analytics.

![ribbon-ipfs](https://user-images.githubusercontent.com/106938/56133912-63bb0200-5f85-11e9-877f-826342dcc565.jpg)

ref: protocol/2019-ipfs-camp#13