### PR TITLE
feat(topnav): add Discuss, remove Media

### DIFF
--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -18,6 +18,7 @@
             <li><a href="/media">Media</a></li>
             <li><a href="//docs.ipfs.io/">Docs</a></li>
             <li><a href="//docs.ipfs.io/#community">Community</a></li>
+            <li><a href="//discuss.ipfs.io">Forum</a></li>
             <li><a href="//blog.ipfs.io/">Blog</a></li>
             <li><a href="/legal/">Legal</a></li>
           </ul>

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -12,8 +12,8 @@
         <li><a href="//docs.ipfs.io/introduction/install/" {{ if eq .page.Params.pagename "install" }}class="current-item"{{ end }}>Install</a></li>
         <li><a href="//docs.ipfs.io/" {{ if and (eq .page.Type "docs") (not (eq .page.Params.pagename "install")) }}class="current-item"{{ end }}>Docs</a></li>
         <li><a href="/team" {{ if eq .page.Type "team" }}class="current-item"{{ end }}>Team</a></li>
-        <li><a href="/media" {{ if eq .page.Type "media" }}class="current-item"{{ end }}>Media</a></li>
         <li><a href="//blog.ipfs.io/" {{ if or (eq .page.Type "blog") (eq .page.Data.Singular "author") }}class="current-item"{{ end }}>Blog</a></li>
+        <li><a href="//discuss.ipfs.io">Discuss</a></li>
       </ul>
     </nav>
     {{ if eq .hero "homepage" }}

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -13,7 +13,7 @@
         <li><a href="//docs.ipfs.io/" {{ if and (eq .page.Type "docs") (not (eq .page.Params.pagename "install")) }}class="current-item"{{ end }}>Docs</a></li>
         <li><a href="/team" {{ if eq .page.Type "team" }}class="current-item"{{ end }}>Team</a></li>
         <li><a href="//blog.ipfs.io/" {{ if or (eq .page.Type "blog") (eq .page.Data.Singular "author") }}class="current-item"{{ end }}>Blog</a></li>
-        <li><a href="//discuss.ipfs.io">Discuss</a></li>
+        <li><a href="//discuss.ipfs.io">Forum</a></li>
       </ul>
     </nav>
     {{ if eq .hero "homepage" }}


### PR DESCRIPTION
This PR aims to address immediate need raised in https://github.com/ipfs/website/issues/236#issuecomment-484010305: 

> We should have a prominent `HOW TO GET HELP` item that send people to discuss. While there is extensive documentation on how to contribute and help others, there is no reference to how actually get help from others.

- Looks like this:
  > ![2019-05-14--19-58-33](https://user-images.githubusercontent.com/157609/57721131-b589a180-7683-11e9-8cc2-26db95e97111.png)

- https://discuss.ipfs.io/ is a good async place to direct people at until we have a proper
"Community" / "Help" /  "Comms" landing page, similar to "Teams"

- "Media" should not be in the top nav, it was not updated for a long time
and gives bad impression of stale development.

- Supersedes https://github.com/ipfs/website/pull/276 and Closes https://github.com/ipfs/website/issues/236