### PR TITLE
Media --> Team in footer

### DIFF
--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -13,7 +13,7 @@
           <ul class="sitemap unstyled">
             <li class="sitemap-head">IPFS</li>
             <li><a href="//github.com/ipfs/ipfs">GitHub</a></li>
-            <li><a href="/team">Media</a></li>
+            <li><a href="/team">Team</a></li>
             <li><a href="//docs.ipfs.io/introduction/install/">Install</a></li>
             <li><a href="/media">Media</a></li>
             <li><a href="//docs.ipfs.io/">Docs</a></li>


### PR DESCRIPTION
Fixes #305 . Changes one of the items in footer from "Media" to "Team" because that's where it links to.