### PR TITLE
Fix broken install link in footer

### DIFF
--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -14,7 +14,7 @@
             <li class="sitemap-head">IPFS</li>
             <li><a href="//github.com/ipfs/ipfs">GitHub</a></li>
             <li><a href="/team">Team</a></li>
-            <li><a href="//docs.ipfs.io/introduction/install/">Install</a></li>
+            <li><a href="//docs.ipfs.io/guides/guides/install/">Install</a></li>
             <li><a href="/media">Media</a></li>
             <li><a href="//docs.ipfs.io/">Docs</a></li>
             <li><a href="//docs.ipfs.io/#community">Community</a></li>


### PR DESCRIPTION
Fixes the issue pointed out here https://discuss.ipfs.io/t/issue-with-https-docs-ipfs-io-introduction-install/5475

All I did was make the install link in `footer.html`, which does not work, match the same link in `header.html` which does work.

Here's the line from `header.html`:

https://github.com/ipfs/website/blob/master/layouts/partials/header.html#L12