### PR TITLE
fix: Use correct project coordinator profile link.

### DIFF
--- a/content/team/index.md
+++ b/content/team/index.md
@@ -50,7 +50,7 @@ Where to learn more:
 - **Roadmap**: https://github.com/ipfs/roadmap/blob/master/WG_PROJECT.md
 - **Working Group Mailing List**: project-wg@ipfs.io
 - **Captain**: **[David Dias](https://github.com/daviddias)** (IPFS Project Lead)
-- **TPM**: **[Molly Mackinlay](https://github.com/daviddias)** (IPFS Project Coordinator)
+- **TPM**: **[Molly Mackinlay](https://github.com/momack2)** (IPFS Project Coordinator)
 
 
 ### JS Core

--- a/content/team/index.md
+++ b/content/team/index.md
@@ -49,8 +49,7 @@ Where to learn more:
 - **Coordination**: https://github.com/ipfs/project
 - **Roadmap**: https://github.com/ipfs/roadmap/blob/master/WG_PROJECT.md
 - **Working Group Mailing List**: project-wg@ipfs.io
-- **Captain**: **[David Dias](https://github.com/daviddias)** (IPFS Project Lead)
-- **TPM**: **[Molly Mackinlay](https://github.com/momack2)** (IPFS Project Coordinator)
+- **Captain**: **[Molly Mackinlay](https://github.com/momack2)**
 
 
 ### JS Core


### PR DESCRIPTION
I noticed a typo as a casual reader. Previously, the link appears to be a copy/paste error in originally writing the page.