### PR TITLE
fix: add robots.txt to exclude gateway paths

### DIFF
--- a/static/robots.txt
+++ b/static/robots.txt
@@ -1,0 +1,5 @@
+# Rationale for excluding gateway paths: https://github.com/ipfs/website/issues/328
+User-Agent: *
+Disallow: /ipfs/
+Disallow: /ipns/
+Disallow: /api/


### PR DESCRIPTION
This PR adds `/robots.txt` and closes https://github.com/ipfs/website/issues/328


cc @andrew