### PR TITLE
Fix macOS consistency

### DIFF
--- a/content/docs/examples/webapps/markdown-viewer/ipfs-readme.md
+++ b/content/docs/examples/webapps/markdown-viewer/ipfs-readme.md
@@ -28,7 +28,7 @@ all dependencies.
   Compilation from source is recommended.
 * If you are interested in development, please install the development
 dependencies as well.
-* *WARNING: older versions of OSX FUSE (for Mac OS X) can cause kernel panics when mounting!*
+* *WARNING: older versions of OSX FUSE (for macOS) can cause kernel panics when mounting!*
   We strongly recommend you use the [latest version of OSX FUSE](http://osxfuse.github.io/).
   (See https://github.com/jbenet/go-ipfs/issues/177)
 

--- a/static/docs/examples/init/README.md
+++ b/static/docs/examples/init/README.md
@@ -88,7 +88,7 @@ sudo service ipfs restart
 
 ## launchd
 
-Similar to `systemd`, on OS X you can run `go-ipfs` via a user LaunchAgent.
+Similar to `systemd`, on macOS you can run `go-ipfs` via a user LaunchAgent.
 
 - Create `~/Library/LaunchAgents/io.ipfs.go-ipfs.plist`:
 

--- a/static/docs/examples/markdown-viewer/ipfs-readme.md
+++ b/static/docs/examples/markdown-viewer/ipfs-readme.md
@@ -28,7 +28,7 @@ all dependencies.
   Compilation from source is recommended.
 * If you are interested in development, please install the development
 dependencies as well.
-* *WARNING: older versions of OSX FUSE (for macOS can cause kernel panics when mounting!*
+* *WARNING: older versions of OSX FUSE (for macOS) can cause kernel panics when mounting!*
   We strongly recommend you use the [latest version of OSX FUSE](http://osxfuse.github.io/).
   (See https://github.com/jbenet/go-ipfs/issues/177)
 

--- a/static/docs/examples/markdown-viewer/ipfs-readme.md
+++ b/static/docs/examples/markdown-viewer/ipfs-readme.md
@@ -28,7 +28,7 @@ all dependencies.
   Compilation from source is recommended.
 * If you are interested in development, please install the development
 dependencies as well.
-* *WARNING: older versions of OSX FUSE (for Mac OS X) can cause kernel panics when mounting!*
+* *WARNING: older versions of OSX FUSE (for macOS can cause kernel panics when mounting!*
   We strongly recommend you use the [latest version of OSX FUSE](http://osxfuse.github.io/).
   (See https://github.com/jbenet/go-ipfs/issues/177)
 


### PR DESCRIPTION
ref #339 
Searched website repo code for "darwin", "mac", "osx" and "os x" and standardized to "macOS" accordingly.