### PR TITLE
Changes Community footer link

### DIFF
--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -15,7 +15,7 @@
             <li><a href="//docs.ipfs.io/guides/guides/install/">Install</a></li>
             <li><a href="//github.com/ipfs/ipfs">GitHub</a></li>
             <li><a href="//docs.ipfs.io/">Docs</a></li>
-            <li><a href="//docs.ipfs.io/#community">Community</a></li>
+            <li><a href="//docs.ipfs.io/community/">Community</a></li>
             <li><a href="//discuss.ipfs.io">Forum</a></li>
             <li><a href="https://awesome.ipfs.io/">Awesome IPFS</a></li>
             <li><a href="https://cluster.ipfs.io/">IPFS Cluster</a></li>


### PR DESCRIPTION
Changes Community footer link to go to enhanced community landing page per https://github.com/ipfs/docs/pull/357

Ref #307 (but doesn't close it until https://github.com/ipfs/docs/pull/357 also merged)