### PR TITLE
Update install.html

### DIFF
--- a/layouts/partials/install.html
+++ b/layouts/partials/install.html
@@ -88,8 +88,7 @@
             <div class="install-description">
               <h4>Go implementation</h4>
               <p>
-                If you build on Go, then go-ipfs — the main IPFS implementation — is for you. It includes a core
-                implementation, daemon server, command line tooling, and more.
+                If you build on Go, then the main IPFS implementation is for you. Includes core implementation, daemon server, CLI tooling, and more.
               </p>
             </div>
           </div>


### PR DESCRIPTION
Shortens Go implementation text so logo doesn't scale down
closes #350 