### PR TITLE
Remove @olizilla as the GUI captain from the Team page

### DIFF
--- a/content/team/index.md
+++ b/content/team/index.md
@@ -164,7 +164,6 @@ Where to learn more:
 
   - **Coordination**: https://github.com/ipfs/ipfs-gui
   - **Mailing List**: gui-wg@ipfs.io
-  - **Captain**: [Oli Evans](https://github.com/olizilla)
   - **Weekly call**
     - 🕒 Wednesdays at 16:00 UTC
     - 📞 Zoom: https://protocol.zoom.us/j/833247793


### PR DESCRIPTION
It doesn't look like GUI have a replacement captain from the team-mgmt repo: https://github.com/ipfs/team-mgmt/blob/master/TEAMS_ROLES_STRUCTURES.md#ipfs-guiux