### PR TITLE
Update ordering of icons & where the CLI link points

### DIFF
--- a/layouts/partials/install.html
+++ b/layouts/partials/install.html
@@ -7,25 +7,6 @@
         target="_blank"> IPFS Desktop</a>.</h5>
 
     <div class="grid-flex-container">
-
-      <div class="grid-flex-cell-1of2">
-        <a href="https://github.com/ipfs-shipyard/ipfs-companion" target="_blank">
-          <div class="install-item">
-            <div class="install-item-image">
-              <img src="/images/ipfs-companion-hex.png" />
-            </div>
-            <div class="install-description">
-              <h4>Browser extension</h4>
-              <p>
-                The IPFS Companion browser extension upgrades your favorite web browser to use IPFS, enabling you to
-                open
-                ipfs:// URLs and more.
-              </p>
-            </div>
-          </div>
-        </a>
-      </div>
-
       <div class="grid-flex-cell-1of2">
         <a href="https://github.com/ipfs-shipyard/ipfs-desktop" target="_blank">
           <div class="install-item">
@@ -43,9 +24,9 @@
           </div>
         </a>
       </div>
-
+      
       <div class="grid-flex-cell-1of2">
-        <a href="http://docs.ipfs.io/guides/guides/install/" target="_blank">
+        <a href="https://docs-beta.ipfs.io/how-to/command-line-quick-start/#install-ipfs" target="_blank">
           <div class="install-item">
             <div class="install-item-image">
               <img src="/images/command-line-hex.png" />
@@ -56,6 +37,24 @@
                 Just want to install IPFS from the command line? Here are step-by-step instructions for getting you up
                 and
                 running quickly and easily.
+              </p>
+            </div>
+          </div>
+        </a>
+      </div>
+      
+      <div class="grid-flex-cell-1of2">
+        <a href="https://github.com/ipfs-shipyard/ipfs-companion" target="_blank">
+          <div class="install-item">
+            <div class="install-item-image">
+              <img src="/images/ipfs-companion-hex.png" />
+            </div>
+            <div class="install-description">
+              <h4>Browser extension</h4>
+              <p>
+                The IPFS Companion browser extension upgrades your favorite web browser to use IPFS, enabling you to
+                open
+                ipfs:// URLs and more.
               </p>
             </div>
           </div>
@@ -78,7 +77,7 @@
           </div>
         </a>
       </div>
-
+      
       <div class="grid-flex-cell-1of2">
         <a href="https://github.com/ipfs/go-ipfs" target="_blank">
           <div class="install-item">


### PR DESCRIPTION
Based on feedback from jbenet walkthrough: point directly to getting started guide from cli link, reorder icons to move cli up