### PR TITLE
fix: Help → Support in header

### DIFF
--- a/layouts/partials/get-started.html
+++ b/layouts/partials/get-started.html
@@ -144,7 +144,7 @@
               <div class="grid-flex-cell-1of2">
                 <ul>
                   <li>
-                    <a href="help">Discover how to get help and support</a>
+                    <a href="/help">Discover how to get help and support</a>
                   </li>
                   <li>
                     <a href="https://discuss.ipfs.io/t/what-do-you-want-to-do-with-ipfs/6157">Join the conversation

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -16,7 +16,7 @@
         <li><a href="//blog.ipfs.io/"
             {{ if or (eq .page.Type "blog") (eq .page.Data.Singular "author") }}class="current-item" {{ end }}>Blog</a>
         </li>
-        <li><a href="/support">Support</a></li>
+        <li><a href="/help">Help</a></li>
       </ul>
     </nav>
     {{ if eq .hero "homepage" }}


### PR DESCRIPTION
> This is a continuation of #371

Psstt, folks, we forgot to update the main header :grin::droplet: 



Note: It is ok to use `/help` in Hugo, because it will convert it to relative paths in the produced HTML:

```html
<a href="../help">Help</a>
```