### PR TITLE
feat: pretty URLs for privacy policies

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 This project builds out a static site to explain IPFS, ready for deployment on ipfs itself. It uses `hugo` to glue the html together. It provides an informative, public-facing website. The most important things are the words, concepts and links it presents.
 
-Much of the site content is data-driven; take a look at the `data` dir where find the data behind the implementations and bundles information as json.
+The site content is in `content/` directory.
 
 ## Install
 

--- a/content/privacy/index.html
+++ b/content/privacy/index.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta http-equiv="refresh" content="3;url=https://ipfs.io" />
+  <title>Nothing here yet</title>
+</head>
+<body>
+  Nothing here yet. You will be redirected to the main page shortly.
+</body>
+</html>

--- a/content/privacy/ipfs-companion/index.html
+++ b/content/privacy/ipfs-companion/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta http-equiv="refresh" content="0;url=https://github.com/ipfs-shipyard/ipfs-companion/blob/master/PRIVACY-POLICY.md" />
+  <link rel="canonical" href="https://github.com/ipfs-shipyard/ipfs-companion/blob/master/PRIVACY-POLICY.md" />
+  <title>Page Moved</title>
+</head>
+<body>
+  Please wait or click <a href="https://github.com/ipfs-shipyard/ipfs-companion/blob/master/PRIVACY-POLICY.md">here</a>.
+  <!-- This redirect was introduced by https://github.com/ipfs-shipyard/ipfs-companion/issues/896 -->
+</body>
+</html>


### PR DESCRIPTION
This PR adds `/privacy/ipfs-companion/` page which is just a redirect to https://github.com/ipfs-shipyard/ipfs-companion/blob/master/PRIVACY-POLICY.md

The goal is to have user friendly URL for use in Chrome Web Store – see: https://github.com/ipfs-shipyard/ipfs-companion/issues/896

In the future `privacy/` landing page can be created, and we may add similar links for IPFS Desktop, and other apps.
Right now, we only have it for Companion.

