### PR TITLE
Add "All videos" button to home page news section

### DIFF
--- a/layouts/partials/latest.html
+++ b/layouts/partials/latest.html
@@ -38,13 +38,14 @@
           <a href="https://www.youtube.com/playlist?list=PLuhRWgmPaHtTwwGv30nKdhr3GiIAnhbyE" target="_blank">Developers Speak: Building on IPFS</a>
         </li>
       </ul>
+      <a href="https://www.youtube.com/channel/UCdjsUXJ3QawK4O5L1kqqsew" class="button button-outlined" target="_blank" rel="noopener noreferrer">All videos</a>
     </div>
-    
+
     <div class="content-center mb2" style="padding-top: 30px;">
       <h3>Stay on top of the latest</h3>
       <h5>Sign up for the IPFS Weekly newsletter to get project updates, community news, event details, and more. In your inbox, each Tuesday.</h5>
       <a class="button button-primary" href="https://ipfs.us4.list-manage.com/subscribe?u=25473244c7d18b897f5a1ff6b&id=cad54b2230" target="_blank" rel="noopener noreferrer">Subscribe</a>
     </div>
-    
+
   </div>
 </section>

--- a/less/pages/home.less
+++ b/less/pages/home.less
@@ -49,6 +49,17 @@
   }
 }
 
+#latest {
+  .button-outlined {
+    border-color: #00b0e9;
+    color: #00b0e9;
+  }
+  .button-outlined:hover {
+    border-color: #008dba;
+    color: #008dba;
+  }
+}
+
 .latest-list {
   margin-bottom: 0;
 


### PR DESCRIPTION
Adds an "All videos" button under the callout videos on the IPFS home page -- see the "News and more" section in [this preview link](https://bafybeieltqren5gbivmavam532nvlsyxy725bpxqk77zvmaflrdyvu4yxm.ipfs.dweb.link/). 
![image](https://user-images.githubusercontent.com/1507828/86170241-0e123d00-bad8-11ea-91e2-628d6ee5d9b6.png)

Note that there's already a link to the YouTube channel on ipfs.io/media:
![image](https://user-images.githubusercontent.com/1507828/86170354-3e59db80-bad8-11ea-8b74-6ada0f355aef.png)

Closes https://github.com/ipfs/website/issues/389.