### PR TITLE
chore: update ProtoSchool links

### DIFF
--- a/layouts/index.html
+++ b/layouts/index.html
@@ -159,7 +159,7 @@
             <h5>Hands-on learner?</h5>
             <a
               class="button button-primary"
-              href="https://proto.school/#/tutorials"
+              href="https://proto.school/#/tutorials?course=ipfs"
               >Explore ProtoSchool</a
             >
           </div>

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -29,7 +29,7 @@
           <ul class="sitemap unstyled">
             <li class="sitemap-head">ProtoSchool</li>
             <li><a href="https://proto.school/#/tutorials">Tutorials</a></li>
-            <li><a href="https://proto.school/#/chapters">Chapters</a></li>
+            <li><a href="https://proto.school/#/events">Events</a></li>
           </ul>
         </div>
         <div class="grid-flex-cell">

--- a/layouts/partials/get-started.html
+++ b/layouts/partials/get-started.html
@@ -109,7 +109,7 @@
                     help get you started building on IPFS right away
                   </li>
                   <li>
-                    <a href="https://proto.school">Explore interactive
+                    <a href="https://proto.school/#/tutorials?course=ipfs">Explore interactive
                       tutorials</a> for IPFS APIs and much more at ProtoSchool
                   </li>
                 </ul>


### PR DESCRIPTION
- Changes ProtoSchool chapters to events
- Links to the IPFS course rather than all tutorials everywhere except the footer

![image](https://user-images.githubusercontent.com/19171465/87427735-39ecf280-c5af-11ea-9f8c-90d3184877cd.png)
