### PR TITLE
Remove references to Solarnet

### DIFF
--- a/static/docs/examples/network/readme.md
+++ b/static/docs/examples/network/readme.md
@@ -12,13 +12,13 @@ ipfs swarm peers
 Manually connect to a specific peer. If the peer below doesn't work, choose one from the output of `ipfs swarm peers`.
 
 ```sh
-ipfs swarm connect /ip4/104.236.176.52/tcp/4001/ipfs/QmSoLnSGccFuZQJzRadHn95W2CrSFmZuTdDWP8HXaHca9z
+ipfs swarm connect /dnsaddr/bootstrap.libp2p.io/ipfs/QmNnooDu7bfjPFoTZYxMNLWUQJyrVwtbZg5gBMjTezGAJN
 ```
 
 Search for a given peer on the network:
 
 ```sh
-ipfs dht findpeer QmSoLnSGccFuZQJzRadHn95W2CrSFmZuTdDWP8HXaHca9z
+ipfs dht findpeer QmNnooDu7bfjPFoTZYxMNLWUQJyrVwtbZg5gBMjTezGAJN
 ```
 
 By [whyrusleeping](http://github.com/whyrusleeping)


### PR DESCRIPTION
Not sure these docs are even live anymore, but running `ipfs version 0.7.0`, this doc fails

```
  * [/ip4/104.236.176.52/tcp/4001] failed to negotiate security protocol: rsa keys must be >= 2048 bits to be useful
```

This PR removes references to the Solarnet (QmSoL... keys) and points at our newer, snazzier Bootstrap node.
Bonus: this gives more interesting results:

```
$ ipfs dht findpeer QmNnooDu7bfjPFoTZYxMNLWUQJyrVwtbZg5gBMjTezGAJN

/ip4/147.75.109.213/tcp/4001
/ip4/127.0.0.1/tcp/8081/ws
/ip6/::1/tcp/4001
/ip6/2604:1380:1000:6000::1/tcp/4001
/ip4/147.75.109.213/udp/4001/quic
/ip4/127.0.0.1/tcp/4001
/ip4/127.0.0.1/udp/4001/quic
/ip6/::1/udp/4001/quic
/ip6/2604:1380:1000:6000::1/udp/4001/quic
```