### PR TITLE
Fix: Remove hashes from ProtoSchool links

### DIFF
--- a/layouts/index.html
+++ b/layouts/index.html
@@ -159,7 +159,7 @@
             <h5>Hands-on learner?</h5>
             <a
               class="button button-primary"
-              href="https://proto.school/#/tutorials?course=ipfs"
+              href="https://proto.school/tutorials?course=ipfs"
               >Explore ProtoSchool</a
             >
           </div>

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -29,8 +29,8 @@
         <div class="grid-flex-cell">
           <ul class="sitemap unstyled">
             <li class="sitemap-head">ProtoSchool</li>
-            <li><a href="https://proto.school/#/tutorials">Tutorials</a></li>
-            <li><a href="https://proto.school/#/events">Events</a></li>
+            <li><a href="https://proto.school/tutorials">Tutorials</a></li>
+            <li><a href="https://proto.school/events">Events</a></li>
           </ul>
         </div>
         <div class="grid-flex-cell">

--- a/layouts/partials/get-started.html
+++ b/layouts/partials/get-started.html
@@ -23,7 +23,7 @@
               <div class="grid-flex-cell-1of2">
                 <ul>
                   <li>
-                    <a href="https://proto.school/#/mutable-file-system/">Discover
+                    <a href="https://proto.school/mutable-file-system/">Discover
                       how to work with IPFS files and directories</a>
                     in an interactive ProtoSchool tutorial
                   </li>
@@ -109,7 +109,7 @@
                     help get you started building on IPFS right away
                   </li>
                   <li>
-                    <a href="https://proto.school/#/tutorials?course=ipfs">Explore interactive
+                    <a href="https://proto.school/tutorials?course=ipfs">Explore interactive
                       tutorials</a> for IPFS APIs and much more at ProtoSchool
                   </li>
                 </ul>


### PR DESCRIPTION
Although we have redirects setup on ProtoSchool, this PR will help users avoid the redirects by using the canonical urls.