### PR TITLE
fix: include .well-known dir when publishing

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,10 +14,12 @@ jobs:
 
   deploy:
     docker:
-      - image: olizilla/ipfs-dns-deploy:latest
+      - image: olizilla/ipfs-dns-deploy:1.7
         environment:
           DOMAIN: website.ipfs.io
           BUILD_DIR: public
+          # Publish the /.well-known directory too
+          EXTRA_IPFS_CLUSTER_ARGS: "--hidden"
     steps:
       - attach_workspace:
           at: /tmp/workspace


### PR DESCRIPTION
pass the `--hidden` flag to `ipfs-cluster-ctl` when pinning to IPFS so that the `.well-known` folder gets published.

see: https://github.com/ipfs-shipyard/ipfs-dns-deploy/issues/16

License: MIT
Signed-off-by: Oli Evans <oli@tableflip.io>