### PR TITLE
Media page -> IPFS press kit

### DIFF
--- a/content/media/index.md
+++ b/content/media/index.md
@@ -2,127 +2,62 @@
 pagetype: major
 pagename: media
 section: Media
-title: IPFS Videos & Media
+title: IPFS Press Kit
 url: media
 save_as: media/index.html
 constellation: constellation-02.svg
 ---
 
-## IPFS videos
+#### Resources for the media, including explainers, logos, and more.
 
-Looking for a good introduction to IPFS, the latest open meetings from IPFS working groups, or content from IPFS Camp? Find all of these — and more! — on the <strong><a href="https://www.youtube.com/channel/UCdjsUXJ3QawK4O5L1kqqsew" target="_blank">IPFS YouTube channel</a></strong>. You can also watch some of the most frequently viewed IPFS video content below.
+We've created this IPFS press kit to help news and media outlets quickly find material to help understand and explain what IPFS is, who powers the IPFS project, and how it will shape the future of the internet.
+If you're a member of the media and would like to request more information or interviews, please [email](mailto: press@protocol.ai).
 
-<div style="max-width:600px; margin: 2em auto;">
-  <h5>Playlist: IPFS Camp 2019 Keynotes</h5>
-  <iframe class="embed-responsive-item" style="margin-bottom: 2em;" src="https://www.youtube.com/embed/videoseries?list=PLuhRWgmPaHtSkKM3Rzp4MQ0Z1nf5Kq0tl" width="600" height="320" frameborder="0" webkitallowfullscreen mozallowfullscreen allowfullscreen></iframe>
+## About IPFS
 
-  <h5>Playlist: IPFS Camp 2019 Lightning Talks & Demos</h5>
-  <iframe class="embed-responsive-item" style="margin-bottom: 2em;" src="https://www.youtube.com/embed/videoseries?list=PLuhRWgmPaHtQVNQcBaCKg5kKhfOBv45Jb" width="600" height="320" frameborder="0" webkitallowfullscreen mozallowfullscreen allowfullscreen></iframe>
+_Feel free to reprint the following descriptions in their entirety without explicit approval._
 
-  <h5>Playlist: IPFS Camp 2019 Core Courses</h5>
-  <iframe class="embed-responsive-item" src="https://www.youtube.com/embed/videoseries?list=PLuhRWgmPaHtSsHMhjeWpfOzr8tonPaePu" width="600" height="320" frameborder="0" webkitallowfullscreen mozallowfullscreen allowfullscreen></iframe>
-</div>
+#### Long description
 
+IPFS (the InterPlanetary File System) is a peer-to-peer hypermedia protocol for content addressing. An alternative to the HTTP protocol, IPFS builds on the principles of peer-to-peer networking and content-based addressing to create a decentralized, distributed, and trustless data storage and delivery network. With IPFS, users ask for a file and the system finds and delivers the closest copy without the need to trust a centralized delivery source. In addition to more efficient content distribution, IPFS offers improved security, content integrity, and resistance to third-party tampering. _(621 characters/95 words)_
 
-<div class="grid-flex-container">
-  <div class="grid-flex-cell-1of2">
-    <h5>IPFS & the Permanent Web</h5>
-    <iframe class="embed-responsive-item" src="https://www.youtube.com/embed/HUVmypx9HGI"  width="400" height="213" frameborder="0" webkitallowfullscreen mozallowfullscreen allowfullscreen></iframe>
-  </div>
-  <div class="grid-flex-cell-1of2">
-    <h5>IPFS Alpha Demo</h5>
-    <iframe class="embed-responsive-item" src="https://www.youtube.com/embed/8CMxDNuuAiQ" width="400" height="213" frameborder="0" webkitallowfullscreen mozallowfullscreen allowfullscreen></iframe>
-  </div>
-</div>
+#### Short description
 
----
+IPFS (the InterPlanetary File System) is a peer-to-peer network and protocol designed to make the web faster, safer, and more open. IPFS upgrades the web to work peer to peer, addressing data by _what_ it is instead of _where_ it’s located on the network, or who is hosting it. _(282 characters/52 words)_
 
-## Media archive
+#### IPFS and Filecoin
 
-A chronological archive of IPFS news, articles, media coverage, presence in conferences and talks, and more.
+For details on understanding the relationship between IPFS and Filecoin, please see [this guide in Filecoin documentation](https://docs.filecoin.io/about-filecoin/ipfs-and-filecoin/).
 
-### 2020
-- [8 December: Most Influential 2020: Juan Benet: From Idea to Action - CoinDesk](https://www.coindesk.com/juan-benet-most-influential-2020)
-- [8 October: IPFS is paving the way for a new digital economy - Modern Consensus](https://modernconsensus.com/commentary/opinion/ipfs-is-paving-the-way-for-a-new-digital-economy/)
-- [5 May: The Decentralized Web Could Help Preserve The Internet's Data For 1,000 Years. Here's Why We Need IPFS To Build It - TechDirt](https://www.techdirt.com/articles/20200504/16050844431/decentralized-web-could-help-preserve-internets-data-1000-years-heres-why-we-need-ipfs-to-build-it.shtml#comments)
-- [30 April: Latest Version of Open Source IPFS Improves Performance - DevOps.com](https://devops.com/latest-version-of-open-source-ipfs-improves-performance/)
-- [28 April: Decentralized Web Protocol IPFS Has Its Biggest Update So Far - Cointelegraph](https://cointelegraph.com/news/decentralized-web-protocol-ipfs-has-its-biggest-update-so-far)
-- [18 March: InterPlanetary File System Is Uncensorable During Coronavirus News Fog - Coindesk](https://www.coindesk.com/interplanetary-file-system-is-uncensorable-during-coronavirus-news-fog)
-- [2 March: IPFS Emerges as Tool to Distribute Container Images - Container Journal](https://containerjournal.com/topics/container-management/ipfs-emerges-as-tool-to-distribute-container-images/)
-- [20 January: JavaScript Apps go Inter-Planetary at Node+JS Interactive](https://medium.com/@italypaleale/watch-javascript-apps-going-inter-planetary-e33dba615a48)
+## The IPFS ecosystem
 
-### 2019
-- [19 December: A Technical Introduction to IPFS with Héctor Sanjuán - Our Networks 2019](https://www.youtube.com/watch?v=hnigvVuoaIA)
-- [4 December: IPFS, Libp2p & Filecoin with Juan Benet - Zero Knowledge podcast](https://www.zeroknowledge.fm/106?t=0)
-- [17 October: Juan Benet Presents Building Web3 at Web3 Summit 2019](https://www.youtube.com/watch?v=pJOG5Ql7ZD0)
-- [16 October: IPFS Basics Night with ProtoSchool Denver](https://www.youtube.com/watch?v=D3MjB45YZsM)
-- [8 August: Vasco Santos on A Decentralized World, OPO.js](https://www.youtube.com/watch?v=5pHl67qomec)
-- [8 August: Alex Potsides on NPM on IPFS, OPO.js](https://www.youtube.com/watch?v=umNL2VkIHe8)
-- [6 September: Enterprise IPFS for True Supply Chain Provenance — RTrade](https://medium.com/rtrade-technologies/enterprise-ipfs-for-true-supply-chain-provenance-part-1-89524337f27)
-- [8 June: MacVoices #19152: WWDC/AltConf - Andrew Hall of Textile.io Explains IPFS](https://www.youtube.com/watch?v=a1qVSs-poLY)
-- [1 June: Jim Pick on "Visualizing the Decentralized Web" at NodeFest Tokyo](https://www.youtube.com/watch?v=3Y76XWFhoco)
-- [22 May: IPFS – Technology That's Out of This World — Sprint](https://business.sprint.com/blog/ipfs-technology/)
+IPFS is made up of a large number of individuals and teams contributing to the project at a variety of levels, for a variety of individual, non-profit, and corporate projects.
 
-### 2018
-- [26 October: What Exactly is Web3? Juan Benet at Web3 Summit 2018](https://www.youtube.com/watch?v=l44z35vabvA)
-- [8 October: IPFS London Meetup](https://www.youtube.com/playlist?list=PLuhRWgmPaHtRdiy0HKNy4UZ4dKVUVL_KG)
-- [17 September: Cloudflare Goes InterPlanetary](https://blog.cloudflare.com/distributed-web-gateway/)
-- [29 August: Dweb: Building Cooperation and Trust into the Web with IPFS](https://hacks.mozilla.org/2018/08/dweb-building-cooperation-and-trust-into-the-web-with-ipfs/)
-- [6 August: Information Civics: Deconstructing the Power Structures of Large-Scale Social Computing Networks](https://infocivics.com/)
-- [11 January: Volker Mische on NOISE at IPFS Lisbon Meetup](https://www.youtube.com/watch?v=wldudAZTM4E)
-- [11 January: Pedro Teixeira on CRDTs in IPFS at IPFS Lisbon Meetup](https://www.youtube.com/watch?v=2VOF-Z-nLnQ)
-- [11 January: João Santos on Distributed Verifiable Claims at IPFS Lisbon Meetup](https://www.youtube.com/watch?v=4oIvWldzT4o)
+#### Core team
 
-### 2017
-- [31 Oct 2017: Decentralize Computing Before It's Too Late — Juan Benet at EtherealSF](https://www.youtube.com/watch?v=Uo4rOvh8mDM)
-- [30 June: IPFS, CoinList, and the Filecoin ICO with Juan Benet and Dalton Caldwell — Y Combinator](https://www.youtube.com/watch?v=iUVLuXjPAfg)
-- [20 June: Why is Decentralized and Distributed File Storage Critical for a Better Web? — Coin Center](https://coincenter.org/entry/why-is-decentralized-and-distributed-file-storage-critical-for-a-better-web)
-- [18 May: Protocol Labs - BlueYard Capital](https://medium.com/@BlueYard/protocol-labs-35ceff61b031)
-- [18 May: Protocol Labs - Union Square Ventures](https://www.usv.com/blog/protocol-labs)
-- [10 May: Turkey Can’t Block This Copy of Wikipedia - Observer](http://observer.com/2017/05/turkey-wikipedia-ipfs/)
-- [29 April: Ethereum Meets Zcash? Why IPFS Plans a Multi-Blockchain Browser - CoinDesk](https://www.coindesk.com/ethereum-meets-zcash-why-ipfs-plans-a-multi-blockchain-browser/)
+The IPFS project is made up of a series of working groups, populated by many full-time and part-time contributors to core project needs. Learn about current team structure and roles [here](https://github.com/ipfs/team-mgmt/blob/master/TEAMS_ROLES_STRUCTURES.md), or read the [history of the IPFS project](https://docs.ipfs.io/project/history/).
 
-### 2016
-- [8 December: The Next Internet Revolution — Juan Benet at TEDxSanFrancisco](https://www.youtube.com/watch?v=2RCwZDRwk48&t=449s)
-- [23 October: The Decentralized Web — Juan Benet at Silicon Valley Ethereum Meetup](https://www.youtube.com/watch?v=cU-n_m-snxQ&t=12s)
-- [14 September 2016: Distributed Apps with IPFS — Juan Benet at Full Stack Fest 2016](https://www.youtube.com/watch?v=jONZtXMu03w&t=76s)
-- [2 June: Berlin IPFS/Blockstack Meetup at c-base](https://www.youtube.com/watch?v=CAfagNmIeOE)
-- [2 April: IPFS Meetup Berlin](https://www.youtube.com/watch?v=UOC_QqtEJtg)
-- [14 April: OpenBazaar Integrating InterPlanetary File System to Help Keep Stores Open Longer - Nasdaq](http://www.nasdaq.com/article/openbazaar-integrating-interplanetary-file-system-to-help-keep-stores-open-longer-cm606534)
-- [21 January: IPFS Workshop with Juan Benet, Open Knowledge Ireland](https://www.youtube.com/watch?v=S65z5NHfUT0)
-- [15 January: DEVCON1: IPFS - Juan Batiz-Benet](https://www.youtube.com/watch?v=ewpIi1y_KDc)
+#### Open-source community
 
-### 2015
-- [26 October: Redistributing the Web with IPFS + Slides - BattleMeshV8](https://www.youtube.com/watch?v=KGIyneFfiRE)
-- [15 October: Interview with Juan Benet of IPFS at DEVCON1 in London](https://www.youtube.com/watch?v=t7VjUKCdfpg)
-- [21 October: Stanford EE380 - Computer Systems Colloquium](https://www.youtube.com/watch?v=HUVmypx9HGI)
-- [20 October: IPFS Meetup hosted by Sourcegraph, San Francisco CA](https://attending.io/events/ipfs-san-francisco-october-2015)
-- [19 October: Introduction to IPFS (InterPlanetary File System); A Brief Post About a Protocol That Changes Everything](https://www.linkedin.com/pulse/introduction-ipfs-interplanetary-file-system-brief-post-john-lilic?trk=hp-feed-article-title-like)
-- [18 October: Ian Preston - IPFS at Redecentralize Conf, London, UK](https://www.youtube.com/watch?v=TiCUIh7tNtU)
-- [12 October: Epicenter Bitcoin Interviews Juan Benet - Decentralizing The Web With The Inter-Planetary File System (IPFS)](https://epicenter.tv/episode/100/)
-- [12 October: Decentralizing the Web with IPFS](https://blog.resellerclub.com/decentralizing-the-web-with-ipfs/)
-- [9 October: FreeNAS Alpha Ships with IPFS as a Transport](http://www.freenas.org/whats-new/2015/10/announcing-freenas-10-alpha.html)
-- [6-8 October: AndyetConf - Richland, WA](http://andyetconf.com)
-- [4 October: TechCruch - Why The Internet Needs IPFS Before It’s Too Late](https://techcrunch.com/2015/10/04/why-the-internet-needs-ipfs-before-its-too-late/)
-- [23 September: IPFS — Inter-Planetary File System. A For-Life, Decentralised, Privacy Respecting Web](https://medium.com/@mvxlr/ipfs-inter-planetary-file-system-65466e4129c6)
-- [18 September: Motherboard, The InterPlanetary File System Wants to Create a Permanent Web](https://motherboard.vice.com/en_us/article/78xgaq/the-interplanetary-file-system-wants-to-create-a-permanent-web)
-- [11 September: Container Camp - Containers at Hyperspeed](https://container.camp) [(Video)](https://www.youtube.com/watch?v=vaIWRyotz4g) [(Slides)](https://speakerdeck.com/jbenet/containers-at-hyperspeed)
-- [10 September: First Steps Toward Implementing Distributed Permanent Web - IPFS - Hacked.com](https://hacked.com/first-steps-toward-implementing-distributed-permanent-web-ipfs/)
-- [8 September: HTTP is Obsolete. It's Time for the Distributed, Permanent Web](https://blog.neocities.org/its-time-for-the-permanent-web.html) [(HackerNews)](https://news.ycombinator.com/item?id=10187555)
-- [27 August: c-base IPFS Meetup, Berlin, Germany](https://github.com/ipfs/community/issues/41)
-- [25 August: Software Engineering Daily Interviews Juan Benet](https://softwareengineeringdaily.com/2015/08/25/interplanetary-file-system-ipfs-with-juan-benet/)
-- [13-17 August: Towards Universal Access to All Knowledge: Internet Archive - Chaos Communication Camp, Zehdenick, Germany](https://www.youtube.com/watch?v=lKvoVxUQKD0)
-- [3-9 August: Battlemesh, Maribor, Slovenia](http://battlemesh.org) [(Video)](https://www.youtube.com/watch?v=OAkJAPS5yoQ)
-- [23 July: Surf Incubator IPFS Meetup, Seattle, WA](https://www.meetup.com/Seattle-IPFS-Meetup/events/224077819/) [(Video - Kyle Drake Talk)](https://vimeo.com/137657331)
-- [22 July: Ctrl IPFS Meetup, Portland, OR](https://attending.io/events/ipfs-portland-meetup-the-permanent-distributed-web)
-- [22 July: Holger Krekels Keynote - EuroPython 2015, Bilbao, Spain](http://dietzel.me/2015/08/02/EuroPython-2015-Holger-Krekels-Keynote-about-the-interplanetary-filesystem-Wed-22nd-July-2015/)
-- [23-24 May: Data Terra Nemo - Berlin, Germany](http://dtn.is)
-- [22 May: Ethereum IPFS Meetup, Berlin, Germany](https://www.youtube.com/watch?v=QlsBU2moRK4)
-- [5 May: BlockChain University Part 1](https://www.youtube.com/watch?v=JhE_J1-BKJE) and [Part 2](https://www.youtube.com/watch?v=999q3_htKPU)
-- [2 May: Install IPFS on a Raspberry PI 2](https://www.siliconian.com/blog/16-bitcoin-blockchain/23-beginner-s-guide-to-installing-ipfs-on-a-raspberry-pi-2)
-- [23 April: Ethereum Meetup, San Francisco, CA](https://www.youtube.com/watch?v=h73bd9b5pPA)
-- [22 April: O'Reilly Fluent Conf](https://conferences.oreilly.com/fluent/javascript-html-2015/public/schedule/speaker/204938)
-- [20 February: IPFS Alpha Release](https://www.youtube.com/watch?v=8CMxDNuuAiQ)
+As an open-source project, IPFS is home to a vibrant, diverse community of thousands of contributors and participants from all over the globe! Learn more about who they are and where to find them [in the Community section of the IPFS docs](https://docs.ipfs.io/community/).
 
-### 2014
-  - [22 July: Talk at Sourcegraph, IPFS Meetup](https://text.sourcegraph.com/ipfs-the-permanent-web-by-juan-benet-ae9901b338b1) [(Video)](https://www.youtube.com/watch?v=Fa4pckodM9g) [(Slides)](https://speakerdeck.com/jbenet/ipfs-the-permanent-web-at-sourcegraph)
+#### Projects using IPFS
+
+A vast variety of commercial and non-profit projects alike are incorporating IPFS as critical to their goals and success. Many are amenable to talking to the media. Find out more about existing success stories at the following resources:
+
+- [Case studies](https://docs.ipfs.io/concepts/#examples-and-case-studies) for IPFS success stories in a variety of industries
+- Video presentations and demos from IPFS builders and collaborators in our [YouTube channel](https://www.youtube.com/c/IPFSbot/videos)
+- Map of the [IPFS ecosystem of collaborators and builders](/images/ipfs-applications-diagram.png) (fully interactive version coming soon!)
+
+## Logos
+To request official IPFS logos and other graphic elements, please [email](mailto: press@protocol.ai).
+
+## Featured news
+All IPFS-related news can be found on our [Blog & News](http://blog.ipfs.io) page. Items can be filtered by topic for easy access:
+
+- [Blog posts](http://blog.ipfs.io/?category=Blog%20post)
+- [Video content](http://blog.ipfs.io/?category=Video)
+- [News coverage](http://blog.ipfs.io/?category=News%20coverage)
+- [Events](http://blog.ipfs.io/?category=Event)
+
+Additionally, you can get up-to-the minute updates on our [Twitter](https://twitter.com/ipfs) and [YouTube](https://www.youtube.com/channel/UCdjsUXJ3QawK4O5L1kqqsew) channels.

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -21,7 +21,7 @@
             <li><a href="https://awesome.ipfs.io/">Awesome IPFS</a></li>
             <li><a href="https://cluster.ipfs.io/">IPFS Cluster</a></li>
             <li><a href="/team">Team</a></li>
-            <li><a href="/media">Media</a></li>
+            <li><a href="/media">Press Kit</a></li>
             <li><a href="//blog.ipfs.io/">Blog</a></li>
             <li><a href="/legal/">Legal</a></li>
           </ul>

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -21,7 +21,7 @@
             <li><a href="https://awesome.ipfs.io/">Awesome IPFS</a></li>
             <li><a href="https://cluster.ipfs.io/">IPFS Cluster</a></li>
             <li><a href="/team">Team</a></li>
-            <li><a href="/media">Press Kit</a></li>
+            <li><a href="/media">Press</a></li>
             <li><a href="//blog.ipfs.io/">Blog</a></li>
             <li><a href="/legal/">Legal</a></li>
           </ul>

--- a/layouts/partials/latest.html
+++ b/layouts/partials/latest.html
@@ -38,7 +38,7 @@
           <a href="https://www.youtube.com/playlist?list=PLuhRWgmPaHtTwwGv30nKdhr3GiIAnhbyE" target="_blank">Developers Speak: Building on IPFS</a>
         </li>
       </ul>
-      <a href="https://www.youtube.com/channel/UCdjsUXJ3QawK4O5L1kqqsew" class="button button-outlined" target="_blank" rel="noopener noreferrer">All videos</a>
+      <a href="https://blog.ipfs.io/?category=Video" class="button button-outlined" target="_blank" rel="noopener noreferrer">More videos</a>
     </div>
 
     <div class="content-center mb2" style="padding-top: 30px;">


### PR DESCRIPTION
### In this PR
As discussed earlier, once the new IPFS Blog & News site goes live, we want to repurpose the old Media page as a press kit for the following reasons:
- All videos/stories from the old Media page are now in the Blog & News site (and are tagged for easy search/discovery)
- An IPFS press kit has been a known need for a while

### Notes for reviewers
- This page still references the pre-PLv7 org structure, but will be re-pointed as necessary when new org structure material comes online
- Links to individual categories on the Blog & News site don't work here, because the new site hasn't been launched yet (we'll want to merge this PR as soon as the new site goes live)
- Short/long descriptions of IPFS were iterated upon by the larger team in Jan 2021
- This info is a v1 - we can expand and amend in the future!