### PR TITLE
chore: wait for cluster to pin before updating dns

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,7 +14,7 @@ jobs:
 
   deploy:
     docker:
-      - image: olizilla/ipfs-dns-deploy:1.7
+      - image: olizilla/ipfs-dns-deploy:1.8
         environment:
           DOMAIN: website.ipfs.io
           BUILD_DIR: public


### PR DESCRIPTION
update to ipfs-dns-deploy v1.8 which uses the --wait flag so we wait for the site to be fully pinned on cluster before continuing.

see: https://github.com/ipfs-shipyard/ipfs-dns-deploy/pull/19
see: https://github.com/protocol/bifrost-infra/issues/1116

License: MIT
Signed-off-by: Oli Evans <oli@tableflip.io>